### PR TITLE
Respect RID and TargetSDK when determining how to build native assets.

### DIFF
--- a/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
+++ b/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
@@ -52,6 +52,9 @@ namespace DNNE.BuildTasks
         public string OutputPath { get; set; }
 
         [Required]
+        public string RuntimeID { get; set; }
+
+        [Required]
         public string Architecture { get; set; }
 
         [Required]
@@ -76,6 +79,7 @@ DNNE Native Compilation:
     OutputPath:     {OutputPath}
 
 Native Build:
+    RuntimeID:      {RuntimeID}
     Architecture:   {Architecture}
     Configuration:  {Configuration}
     ");

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -43,7 +43,7 @@ namespace DNNE.BuildTasks
             export.Report(CreateCompileCommand.DevImportance, $"VS Install: {vsInstall}\nVC Tools: {vcToolDir}\nWinSDK Version: {winSdk.Version}");
 
             bool isDebug = IsDebug(export.Configuration);
-            bool is64Bit = Is64BitTarget(export.Architecture);
+            bool is64Bit = Is64BitTarget(export.Architecture, export.RuntimeID);
 
             var archDir = is64Bit ? "x64" : "x86";
 
@@ -94,14 +94,15 @@ namespace DNNE.BuildTasks
             commandArguments = $"{compilerFlags} /link {linkerFlags}";
         }
 
-        private static bool Is64BitTarget(string arch)
+        private static bool Is64BitTarget(string arch, string rid)
         {
             return arch.ToLower() switch
             {
                 "x64" => true,
                 "amd64" => true,
                 "x86" => false,
-                _ => IntPtr.Size == 8,
+                "msil" => rid.Contains("x64"), // e.g. win-x86, win-x64, etc
+                _ => IntPtr.Size == 8, // Fallback is the process bitness
             };
         }
 

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -102,6 +102,7 @@ DNNE.targets
         Source="$([MSBuild]::NormalizePath($(__DnneGeneratedSourceFile)))"
         OutputName="$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)"
         OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
+        RuntimeID="$(DnneRuntimeIdentifier)"
         Architecture="$(TargetedSDKArchitecture)"
         Configuration="$(Configuration)">
       <Output TaskParameter="Command" PropertyName="CompilerCmd" />


### PR DESCRIPTION
Fixes #29 