### PR TITLE
Native compiler customization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,9 +95,9 @@ The following attributes can be used to enable the above scenario. They should b
     /// <remarks>
     /// This attribute is respected on an exported method declaration or on a parameter for the method.
     /// The following header files will be included prior to the code being defined.
-    ///   stddef.h
-    ///   stdint.h
-    ///   dnne.h
+    ///   - stddef.h
+    ///   - stdint.h
+    ///   - dnne.h
     /// </remarks>
     internal class C99DeclCodeAttribute : System.Attribute
     {
@@ -143,6 +143,12 @@ public unsafe static class NativeExports
 }
 ```
 
+In addition to providing declaration code directly, users can also supply `#include` directives for application specific headers. The [`DnneAdditionalIncludeDirectories`](./src/msbuild/DNNE.props) MSBuild property can be used to supply search paths in these cases. Consider the following use of the `DNNE.C99DeclCode` attribute.
+
+```CSharp
+[DNNE.C99DeclCode("#include <fancyapp.h>")]
+```
+
 ## Generating a native binary using the DNNE NuPkg
 
 1) The DNNE NuPkg is published on [NuGet.org](https://www.nuget.org/packages/DNNE), but can also be built locally.
@@ -152,6 +158,8 @@ public unsafe static class NativeExports
         `> dotnet build create_package.proj`
 
 1) Add the NuPkg to the target managed project.
+
+    * See [`DNNE.props`](./src/msbuild/DNNE.props) for the MSBuild properties used to configure the build process.
 
     * If NuPkg was built locally, remember to update the projects `nuget.config` to point at the local location of the recently built DNNE NuPkg.
 

--- a/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
+++ b/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
@@ -21,6 +21,8 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace DNNE.BuildTasks
@@ -59,6 +61,18 @@ namespace DNNE.BuildTasks
 
         [Required]
         public string Configuration { get; set; }
+
+        // Optional
+        public string CommandOverride { get; set; }
+
+        // Optional
+        public ITaskItem[] AdditionalIncludeDirectories { get; set; }
+
+        // Used to avoid null cases
+        internal IEnumerable<ITaskItem> SafeAdditionalIncludeDirectories
+        {
+            get => AdditionalIncludeDirectories ?? Enumerable.Empty<ITaskItem>();
+        }
 
         [Output]
         public string Command { get; set; }
@@ -103,7 +117,7 @@ Native Build:
                 throw new NotSupportedException("Unknown native build environment");
             }
 
-            this.Command = command;
+            this.Command = string.IsNullOrEmpty(this.CommandOverride) ? command : this.CommandOverride;
             this.CommandArguments = commandArguments;
 
             return true;

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -70,6 +70,13 @@ namespace DNNE.BuildTasks
                 compilerFlags.Append($"/I \"{incPath}\" ");
             }
 
+            // Add user defined inc paths last - these will be searched last on MSVC.
+            // https://docs.microsoft.com/cpp/build/reference/i-additional-include-directories#remarks
+            foreach (var incPath in export.SafeAdditionalIncludeDirectories)
+            {
+                compilerFlags.Append($"/I \"{incPath}\" ");
+            }
+
             compilerFlags.Append($"\"{export.Source}\" \"{Path.Combine(export.PlatformPath, "platform.c")}\" ");
 
             // Set linker flags

--- a/src/msbuild/DNNE.BuildTasks/macOS.cs
+++ b/src/msbuild/DNNE.BuildTasks/macOS.cs
@@ -45,6 +45,14 @@ namespace DNNE.BuildTasks
             compilerFlags.Append($"-shared -fpic ");
             compilerFlags.Append($"-D DNNE_ASSEMBLY_NAME={export.AssemblyName} -D DNNE_COMPILE_AS_SOURCE ");
             compilerFlags.Append($"-I \"{export.PlatformPath}\" -I \"{export.NetHostPath}\" ");
+
+            // Add user defined inc paths last - these will be searched last on clang.
+            // https://clang.llvm.org/docs/ClangCommandLineReference.html#include-path-management
+            foreach (var incPath in export.SafeAdditionalIncludeDirectories)
+            {
+                compilerFlags.Append($"-I \"{incPath}\" ");
+            }
+
             compilerFlags.Append($"-o \"{Path.Combine(export.OutputPath, export.OutputName)}\" ");
             compilerFlags.Append($"\"{export.Source}\" \"{Path.Combine(export.PlatformPath, "platform.c")}\" ");
             compilerFlags.Append($"-lstdc++ ");

--- a/src/msbuild/DNNE.props
+++ b/src/msbuild/DNNE.props
@@ -26,7 +26,7 @@ DNNE.props
   <PropertyGroup>
     <DnneGenerateExports>true</DnneGenerateExports>
 
-    <!-- If the build is disabled, the generated is considered the output
+    <!-- If the build is disabled, the generated source is considered the output
         and emitted in the output directory as if it were a binary. -->
     <DnneBuildExports>true</DnneBuildExports>
 
@@ -44,5 +44,16 @@ DNNE.props
 
     <!-- Enable a workaround for https://github.com/dotnet/sdk/issues/1675 -->
     <DnneWorkAroundSdk1675>true</DnneWorkAroundSdk1675>
+
+    <!-- Set to override the computed native compiler command.
+        This value will be placed in double quotes (e.g. "command") and passed
+        the computed compiler arguments. -->
+    <DnneCompilerCommand></DnneCompilerCommand>
+
+    <!-- Set to add additional include paths to use during the native build.
+        The directories should be semicolon (e.g. C:\Foo;D:\Bar) delimited.
+        These additional directories are appended to the end of the compiler
+        search paths. -->
+    <DnneAdditionalIncludeDirectories></DnneAdditionalIncludeDirectories>
   </PropertyGroup>
 </Project>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -108,6 +108,10 @@ DNNE.targets
       <__DnneGeneratedSourceFile>@(DnneGeneratedSourceFile)</__DnneGeneratedSourceFile>
     </PropertyGroup>
 
+    <ItemGroup>
+      <__DnneAdditionalIncludeDirectories Include="$(DnneAdditionalIncludeDirectories)" />
+    </ItemGroup>
+
     <CreateCompileCommand
         AssemblyName="$(DnneAssemblyName)"
         NetHostPath="$([MSBuild]::NormalizePath($(DnneNetHostDir)))"
@@ -117,7 +121,9 @@ DNNE.targets
         OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
         RuntimeID="$(DnneRuntimeIdentifier)"
         Architecture="$(TargetedSDKArchitecture)"
-        Configuration="$(Configuration)">
+        Configuration="$(Configuration)"
+        CommandOverride="$(DnneCompilerCommand)"
+        AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
       <Output TaskParameter="Command" PropertyName="CompilerCmd" />
       <Output TaskParameter="CommandArguments" PropertyName="CompilerArgs" />
     </CreateCompileCommand>


### PR DESCRIPTION
Allow users to provide their own compiler command. This enables
cases where users want to use gcc instead of clang. Also accept
additional include search paths.

Fixes #40 