### PR TITLE
Don't use both project path and intermediate output path when calculating output folder.

### DIFF
--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -26,7 +26,7 @@ DNNE.targets
   <PropertyGroup>
     <DnneNativeExportsBinaryName>$(TargetName)$(DnneNativeBinarySuffix)</DnneNativeExportsBinaryName>
     <DnneNativeExportsBinaryPath>$(TargetDir)</DnneNativeExportsBinaryPath>
-    <DnneGeneratedOutputPath>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)dnne</DnneGeneratedOutputPath>
+    <DnneGeneratedOutputPath>$(IntermediateOutputPath)dnne</DnneGeneratedOutputPath>
     <DnneGeneratedBinPath>$(DnneGeneratedOutputPath)/bin</DnneGeneratedBinPath>
 
     <!-- If build was disabled, change the generated output directory to


### PR DESCRIPTION
The `IntermediateOutputPath` property is already a full path.

This seems to work today because `IntermediateOutputPath` is a subpath of `$(MSBuildProjectDirectory)` by default, but this breaks when `$(IntermediateOutputPath)` is in a different path. This fix unblocks enabling CI with Arcade for DllImportGenerator.