### PR TITLE
Convert the Source property on the build task from ITaskItem to string.

### DIFF
--- a/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
+++ b/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
@@ -45,7 +45,7 @@ namespace DNNE.BuildTasks
         public string PlatformPath { get; set; }
 
         [Required]
-        public ITaskItem Source { get; set; }
+        public string Source { get; set; }
 
         [Required]
         public string OutputName { get; set; }
@@ -69,6 +69,10 @@ namespace DNNE.BuildTasks
         public ITaskItem[] AdditionalIncludeDirectories { get; set; }
 
         // Used to avoid null cases
+        // N.B. The ToString() method on an ITaskItem returns the escaped
+        // item spec. This is typically not what is desired if being passed
+        // to a command line tool. In order to get the unescaped item spec use
+        // the ITaskItem.ItemSpec property.
         internal IEnumerable<ITaskItem> SafeAdditionalIncludeDirectories
         {
             get => AdditionalIncludeDirectories ?? Enumerable.Empty<ITaskItem>();

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -74,7 +74,7 @@ namespace DNNE.BuildTasks
             // https://docs.microsoft.com/cpp/build/reference/i-additional-include-directories#remarks
             foreach (var incPath in export.SafeAdditionalIncludeDirectories)
             {
-                compilerFlags.Append($"/I \"{incPath}\" ");
+                compilerFlags.Append($"/I \"{incPath.ItemSpec}\" ");
             }
 
             compilerFlags.Append($"\"{export.Source}\" \"{Path.Combine(export.PlatformPath, "platform.c")}\" ");

--- a/src/msbuild/DNNE.BuildTasks/macOS.cs
+++ b/src/msbuild/DNNE.BuildTasks/macOS.cs
@@ -50,7 +50,7 @@ namespace DNNE.BuildTasks
             // https://clang.llvm.org/docs/ClangCommandLineReference.html#include-path-management
             foreach (var incPath in export.SafeAdditionalIncludeDirectories)
             {
-                compilerFlags.Append($"-I \"{incPath}\" ");
+                compilerFlags.Append($"-I \"{incPath.ItemSpec}\" ");
             }
 
             compilerFlags.Append($"-o \"{Path.Combine(export.OutputPath, export.OutputName)}\" ");


### PR DESCRIPTION
This fixes an issue when calling `ToString()` on a `TaskItem`. Using `ToString()` returns the escaped item spec - which is not typically usable from a command line tool.

Fixes #50 