### PR TITLE
Support supplying a def file on Windows.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ This work is inspired by work in the [Xamarin][xamarin_embed_link], [CoreRT][cor
     }
     ```
 
+- The manner in which native exports are exposed is largely a function of the compiler being used. On the Windows platform an option exists to provide a [`.def`](https://docs.microsoft.com/cpp/build/reference/exports) file that permits customization of native exports. Users can provide a path to a `.def` file using the [`DnneWindowsExportsDef`](./src/msbuild/DNNE.props) MSBuild property. Note that if a `.def` file is provided no user functions will be exported by default.
+
 <a name="nativeapi"></a>
 
 ## Native API
@@ -70,7 +72,7 @@ The `preload_runtime()` function can be used to preload the runtime. This may be
     - Optionally set the `EntryPoint` property to indicate the name of the native export. See below for discussion of influence by calling convention.
     - If the `EntryPoint` property is `null`, the name of the mananged function is used. This default name will not include the namespace or class containing the function.
     - User supplied values in `EntryPoint` will not be modified or validated in any manner. This string will be consume by a C compiler and should therefore adhere to the [C language's restrictions on function names](https://en.cppreference.com/w/c/language/functions).
-    - On the x86 platform only, multiple calling conventions exist and these often influence exported symbols. For example, see MSVC [C export decoration documentation](https://docs.microsoft.com/cpp/build/reference/decorated-names#FormatC). DNNE does not attempt to mitigate symbol decoration - even through `EntryPoint`. If the consuming application requires a specific export symbol _and_ calling convention that is decorated in a customized way, it is recommended to manually compile the generated source - see [`DnneBuildExports`](./src/msbuild/DNNE.props). Typically, setting the calling convention to `cdecl` for the export will address issues on any x86 platform.
+    - On the x86 platform only, multiple calling conventions exist and these often influence exported symbols. For example, see MSVC [C export decoration documentation](https://docs.microsoft.com/cpp/build/reference/decorated-names#FormatC). DNNE does not attempt to mitigate symbol decoration - even through `EntryPoint`. If the consuming application requires a specific export symbol _and_ calling convention that is decorated in a customized way, it is recommended to manually compile the generated source - see [`DnneBuildExports`](./src/msbuild/DNNE.props) - or if on Windows supply a `.def` file - see [`DnneWindowsExportsDef`](./src/msbuild/DNNE.props). Typically, setting the calling convention to `cdecl` for the export will address issues on any x86 platform.
         ```CSharp
         [UnmanagedCallersOnly(CallConvs = new []{typeof(System.Runtime.CompilerServices.CallConvCdecl)})]
         ```

--- a/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
+++ b/src/msbuild/DNNE.BuildTasks/CreateCompileCommand.cs
@@ -22,6 +22,7 @@ using Microsoft.Build.Utilities;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -66,6 +67,24 @@ namespace DNNE.BuildTasks
         public string CommandOverride { get; set; }
 
         // Optional
+        public string ExportsDefFile { get; set; }
+
+        // Used to ensure the supplied path is absolute and
+        // can be supplied as-is in a command line scenario.
+        internal string AbsoluteExportsDefFilePath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ExportsDefFile))
+                {
+                    return null;
+                }
+
+                return Path.GetFullPath(ExportsDefFile);
+            }
+        }
+
+        // Optional
         public ITaskItem[] AdditionalIncludeDirectories { get; set; }
 
         // Used to avoid null cases
@@ -93,6 +112,7 @@ DNNE Native Compilation:
     NetHostPath:    {NetHostPath}
     PlatformPath:   {PlatformPath}
     Source:         {Source}
+    ExportsDefFile: {ExportsDefFile}
     OutputName:     {OutputName}
     OutputPath:     {OutputPath}
 

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -62,6 +62,15 @@ namespace DNNE.BuildTasks
             // Set compiler flags
             compilerFlags.Append($"/TC /MT /GS /Zi ");
             compilerFlags.Append($"/D DNNE_ASSEMBLY_NAME={export.AssemblyName} /D DNNE_COMPILE_AS_SOURCE ");
+
+            // Check if user supplied a def file.
+            string exportsDefFile = export.AbsoluteExportsDefFilePath;
+            if (!string.IsNullOrEmpty(exportsDefFile))
+            {
+                // The macro needs to be empty, not just defined.
+                compilerFlags.Append($"/D DNNE_API_OVERRIDE= ");
+            }
+
             compilerFlags.Append($"/I \"{vcIncDir}\" /I \"{export.PlatformPath}\" /I \"{export.NetHostPath}\" ");
 
             // Add WinSDK inc paths
@@ -81,6 +90,12 @@ namespace DNNE.BuildTasks
 
             // Set linker flags
             linkerFlags.Append($"/DLL /LTCG ");
+
+            if (!string.IsNullOrEmpty(exportsDefFile))
+            {
+                linkerFlags.Append($"/DEF:\"{exportsDefFile}\" ");
+            }
+
             linkerFlags.Append($"/LIBPATH:\"{libDir}\" ");
 
             // Add WinSDK lib paths

--- a/src/msbuild/DNNE.props
+++ b/src/msbuild/DNNE.props
@@ -53,6 +53,12 @@ DNNE.props
         the computed compiler arguments. -->
     <DnneCompilerCommand></DnneCompilerCommand>
 
+    <!-- Provide a .def file to pass to the Windows Linker for controlling
+        how exports are handled. This is only passed to the linker on
+        the Windows platform.
+        See https://docs.microsoft.com/cpp/build/exporting-from-a-dll-using-def-files -->
+    <DnneWindowsExportsDef></DnneWindowsExportsDef>
+
     <!-- Set to add additional include paths to use during the native build.
         The directories should be semicolon (e.g. C:\Foo;D:\Bar) delimited.
         These additional directories are appended to the end of the compiler

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -128,6 +128,7 @@ DNNE.targets
         Architecture="$(TargetedSDKArchitecture)"
         Configuration="$(Configuration)"
         CommandOverride="$(DnneCompilerCommand)"
+        ExportsDefFile="$(DnneWindowsExportsDef)"
         AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
       <Output TaskParameter="Command" PropertyName="CompilerCmd" />
       <Output TaskParameter="CommandArguments" PropertyName="CompilerArgs" />

--- a/src/platform/dnne.h
+++ b/src/platform/dnne.h
@@ -45,6 +45,13 @@
     #define DNNE_STR(s) s
 #endif
 
+// Override the DNNE_API macro.
+// This is typically used to dictate the export semantics of functions.
+#ifdef DNNE_API_OVERRIDE
+    #undef DNNE_API
+    #define DNNE_API DNNE_API_OVERRIDE
+#endif
+
 //
 // Public exports
 //


### PR DESCRIPTION
This will permit the ability to override the default export semantics.

Fixes #63