### PR TITLE
Look up known types by assembly-qualified name by string comparison instead of loading into the process.

### DIFF
--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -625,28 +625,24 @@ $@"#endif // {generatedHeaderDefine}
 
             public KnownType GetTypeFromSerializedName(string name)
             {
-                if (Type.GetType(name).Name.Equals(nameof(CallingConvention)))
+                int typeAssemblySeparator = name.IndexOf(',');
+                string typeName = name[..typeAssemblySeparator];
+                string assemblyName = name[(typeAssemblySeparator + 1)..];
+                string assemblySimpleName = assemblyName;
+                int simpleNameEnd = assemblySimpleName.IndexOf(',');
+                if (simpleNameEnd != -1)
                 {
-                    return KnownType.CallingConvention;
+                    assemblySimpleName = assemblySimpleName[..simpleNameEnd];
                 }
-                else if (Type.GetType(name).Name.Equals(nameof(CallConvCdecl)))
+                return (typeName, assemblySimpleName) switch
                 {
-                    return KnownType.CallConvCdecl;
-                }
-                else if (Type.GetType(name).Name.Equals(nameof(CallConvStdcall)))
-                {
-                    return KnownType.CallConvStdcall;
-                }
-                else if (Type.GetType(name).Name.Equals(nameof(CallConvThiscall)))
-                {
-                    return KnownType.CallConvThiscall;
-                }
-                else if (Type.GetType(name).Name.Equals(nameof(CallConvFastcall)))
-                {
-                    return KnownType.CallConvFastcall;
-                }
-
-                return KnownType.Unknown;
+                    ("System.Runtime.InteropServices.CallingConvention", "System.Runtime.InteropServices") => KnownType.CallingConvention,
+                    ("System.Runtime.CompilerServices.CallConvCdecl", "System.Runtime") => KnownType.CallConvCdecl,
+                    ("System.Runtime.CompilerServices.CallConvStdcall", "System.Runtime") => KnownType.CallConvStdcall,
+                    ("System.Runtime.CompilerServices.CallConvThiscall", "System.Runtime") => KnownType.CallConvThiscall,
+                    ("System.Runtime.CompilerServices.CallConvFastcall", "System.Runtime") => KnownType.CallConvFastcall,
+                    _ => KnownType.Unknown
+                };
             }
 
             public PrimitiveTypeCode GetUnderlyingEnumType(KnownType type)

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -634,7 +634,8 @@ $@"#endif // {generatedHeaderDefine}
                 {
                     assemblySimpleName = assemblySimpleName[..simpleNameEnd];
                 }
-                return (typeName, assemblySimpleName) switch
+
+                return (typeName, assemblySimpleName.TrimStart()) switch
                 {
                     ("System.Runtime.InteropServices.CallingConvention", "System.Runtime.InteropServices") => KnownType.CallingConvention,
                     ("System.Runtime.CompilerServices.CallConvCdecl", "System.Runtime") => KnownType.CallConvCdecl,

--- a/test/ExportingAssembly/IntExports.cs
+++ b/test/ExportingAssembly/IntExports.cs
@@ -17,6 +17,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace ExportingAssembly
@@ -74,6 +75,12 @@ namespace ExportingAssembly
 
         [UnmanagedCallersOnly]
         public static void UnmanagedIntVoid(int a)
+        {
+            IntVoid(a);
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new [] { typeof(CallConvCdecl) })]
+        public static void UnmanagedIntVoidCdecl(int a)
         {
             IntVoid(a);
         }


### PR DESCRIPTION
Fixes #72