### PR TITLE
Use the C standard errno.h header instead of the GCC-specific sys/errno.h

### DIFF
--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -219,7 +219,7 @@ static void set_current_error(int err)
 #include <dlfcn.h>
 #include <limits.h>
 #include <string.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #define DNNE_NORETURN __attribute__((__noreturn__))
 #define DNNE_DIR_SEPARATOR '/'


### PR DESCRIPTION
Alpine doesn't support the sys/errno.h header and emits a warning when redirecting the include.

See https://dev.azure.com/dnceng/public/_build/results?buildId=1399511&view=logs&j=3cb0d069-7bfd-5845-3f2b-3f0219fe1975&t=f32c8f8b-0718-5785-0642-67a45b7d0ab2&l=2538