### PR TITLE
Add support and tests for compiling with g++

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,14 @@ jobs:
       run: dotnet build src/create_package.proj -c ${{ matrix.flavor }}
     - name: Unit Test Product
       run: dotnet test test/DNNE.UnitTests -c ${{ matrix.flavor }}
-    - name: Unit Test Product (GCC)
+    - name: Unit Test Product (gcc)
       run: |
         dotnet clean test/DNNE.UnitTests -c ${{ matrix.flavor }}
         dotnet test test/DNNE.UnitTests -c ${{ matrix.flavor }} -p:BuildWithGCC=true
+    - name: Unit Test Product (g++)
+      run: |
+        dotnet clean test/DNNE.UnitTests -c ${{ matrix.flavor }}
+        dotnet test test/DNNE.UnitTests -c ${{ matrix.flavor }} -p:BuildWithGPP=true
 
   windows:
     runs-on: windows-latest

--- a/readme.md
+++ b/readme.md
@@ -249,11 +249,11 @@ public class Exports
 
 [dotnet repo](https://github.com/dotnet/runtime)
 
-[`nethost` example](https://github.com/dotnet/samples/tree/master/core/hosting/HostWithHostFxr)
+[`nethost` example](https://github.com/dotnet/samples/tree/main/core/hosting)
 
 <!-- Links -->
 [xamarin_embed_link]: https://docs.microsoft.com/xamarin/tools/dotnet-embedding/release-notes/preview/0.4
 [corert_feature_link]: https://github.com/dotnet/corert/tree/master/samples/NativeLibrary
 [dllexport_link]: https://github.com/3F/DllExport
-[csharp_funcptr_link]: https://github.com/dotnet/csharplang/blob/master/proposals/function-pointers.md
+[csharp_funcptr_link]: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/function-pointers.md
 [unmanagedcallersonly_link]: https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -652,7 +652,7 @@ extern void* get_fast_callable_managed_function(
                     acquireManagedFunction =
 $@"const char_t* methodName = DNNE_STR(""{export.MethodName}"");
         const char_t* delegateType = DNNE_STR(""{export.EnclosingTypeName}+{export.MethodName}Delegate, {assemblyName}"");
-        {export.ExportName}_ptr = get_callable_managed_function({classNameConstant}, methodName, delegateType);";
+        {export.ExportName}_ptr = ({export.ReturnType}({callConv}*)({declsig}))get_callable_managed_function({classNameConstant}, methodName, delegateType);";
 
                 }
                 else
@@ -660,7 +660,7 @@ $@"const char_t* methodName = DNNE_STR(""{export.MethodName}"");
                     Debug.Assert(export.Type == ExportType.UnmanagedCallersOnly);
                     acquireManagedFunction =
 $@"const char_t* methodName = DNNE_STR(""{export.MethodName}"");
-        {export.ExportName}_ptr = get_fast_callable_managed_function({classNameConstant}, methodName);";
+        {export.ExportName}_ptr = ({export.ReturnType}({callConv}*)({declsig}))get_fast_callable_managed_function({classNameConstant}, methodName);";
                 }
 
                 // Declare export

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -666,14 +666,14 @@ $@"const char_t* methodName = DNNE_STR(""{export.MethodName}"");
                 // Declare export
                 outputStream.WriteLine(
 $@"{preguard}// Computed from {export.EnclosingTypeName}{Type.Delimiter}{export.MethodName}
-DNNE_API {export.ReturnType} {callConv} {export.ExportName}({declsig});
+DNNE_EXTERN_C DNNE_API {export.ReturnType} {callConv} {export.ExportName}({declsig});
 {postguard}");
 
                 // Define export in implementation stream
                 implStream.WriteLine(
 $@"{preguard}// Computed from {export.EnclosingTypeName}{Type.Delimiter}{export.MethodName}
 static {export.ReturnType} ({callConv}* {export.ExportName}_ptr)({declsig});
-DNNE_API {export.ReturnType} {callConv} {export.ExportName}({declsig})
+DNNE_EXTERN_C DNNE_API {export.ReturnType} {callConv} {export.ExportName}({declsig})
 {{
     if ({export.ExportName}_ptr == NULL)
     {{

--- a/src/dnne-pkg/dnne-pkg.csproj
+++ b/src/dnne-pkg/dnne-pkg.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PackageId>DNNE</PackageId>
-    <Version>1.0.27</Version>
+    <Version>1.0.28</Version>
     <Authors>AaronRobinsonMSFT</Authors>
     <Owners>AaronRobinsonMSFT</Owners>
     <Description>Package used to generated native exports for .NET assemblies.</Description>

--- a/src/platform/dnne.h
+++ b/src/platform/dnne.h
@@ -43,16 +43,16 @@
     #define DNNE_STR(s) _DNNE_STR(s)
 #else
     #define DNNE_API __attribute__((__visibility__("default")))
-    #define DNNE_CALLTYPE 
-    #define DNNE_CALLTYPE_CDECL 
+    #define DNNE_CALLTYPE
+    #define DNNE_CALLTYPE_CDECL
     #ifdef __i386__
         #define DNNE_CALLTYPE_STDCALL __attribute__((stdcall))
         #define DNNE_CALLTYPE_THISCALL __attribute__((thiscall))
         #define DNNE_CALLTYPE_FASTCALL __attribute__((fastcall))
     #else
-        #define DNNE_CALLTYPE_STDCALL 
-        #define DNNE_CALLTYPE_THISCALL 
-        #define DNNE_CALLTYPE_FASTCALL 
+        #define DNNE_CALLTYPE_STDCALL
+        #define DNNE_CALLTYPE_THISCALL
+        #define DNNE_CALLTYPE_FASTCALL
     #endif
     #define DNNE_STR(s) s
 #endif
@@ -74,6 +74,14 @@ enum failure_type
 };
 typedef void (DNNE_CALLTYPE* failure_fn)(enum failure_type type, int error_code);
 
+#ifdef __cplusplus
+    #define DNNE_EXTERN_C extern "C"
+    DNNE_EXTERN_C
+    {
+#else
+    #define DNNE_EXTERN_C
+#endif
+
 // Provide a callback for any catastrophic failures.
 // The provided callback will be the last call prior to a rude-abort of the process.
 // See dnne_abort().
@@ -88,5 +96,9 @@ DNNE_API void DNNE_CALLTYPE preload_runtime(void);
 // Users can override DNNE's rude-abort behavior by providing their own dnne_abort() at link time.
 // It is expected this function will not return. If it does return, the behavior is undefined.
 extern DNNE_API void dnne_abort(enum failure_type type, int error_code);
+
+#ifdef __cplusplus
+    }
+#endif
 
 #endif // __SRC_PLATFORM_DNNE_H__

--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -30,7 +30,7 @@
 #include <nethost.h>
 
 // Needed for dladdr() in non-macOS scenarios
-#if !defined(DNNE_WINDOWS) && !defined(DNNE_OSX)
+#if !defined(DNNE_WINDOWS) && !defined(DNNE_OSX) && !defined(_GNU_SOURCE)
     #define _GNU_SOURCE
 #endif
 

--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -276,7 +276,7 @@ static void set_current_error(int err)
 
 static failure_fn failure_fptr;
 
-DNNE_API void DNNE_CALLTYPE set_failure_callback(failure_fn cb)
+DNNE_EXTERN_C DNNE_API void DNNE_CALLTYPE set_failure_callback(failure_fn cb)
 {
     failure_fptr = cb;
 }
@@ -300,7 +300,7 @@ DNNE_API void DNNE_CALLTYPE set_failure_callback(failure_fn cb)
     #define DNNE_DEFAULT_IMPL(methodName, ...) __attribute__((weak)) methodName(__VA_ARGS__)
 #endif
 
-DNNE_API void DNNE_DEFAULT_IMPL(dnne_abort, enum failure_type type, int error_code)
+DNNE_EXTERN_C DNNE_API void DNNE_DEFAULT_IMPL(dnne_abort, enum failure_type type, int error_code)
 {
     abort();
 }
@@ -471,7 +471,7 @@ static void prepare_runtime(void)
     assert(get_managed_export_fptr != NULL);
 }
 
-DNNE_API void DNNE_CALLTYPE preload_runtime(void)
+DNNE_EXTERN_C DNNE_API void DNNE_CALLTYPE preload_runtime(void)
 {
     prepare_runtime();
 }

--- a/test/ExportingAssembly/ExportingAssembly.csproj
+++ b/test/ExportingAssembly/ExportingAssembly.csproj
@@ -19,6 +19,7 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
     <DnneCompilerCommand Condition="'$(BuildWithGCC)'=='true'">gcc</DnneCompilerCommand>
+    <DnneCompilerCommand Condition="'$(BuildWithGPP)'=='true'">g++</DnneCompilerCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestNuPkg)' == 'true' AND '$(RefLocalBuild)'=='true'">


### PR DESCRIPTION
Update links in readme.md

Addresses issues described in https://github.com/AaronRobinsonMSFT/DNNE/issues/104#issuecomment-995446162

This PR adds support for compiling DNNE generated source and infrastructure code as C++ with g++.