### PR TITLE
Add support for Xml code documentation exported to header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,7 +245,7 @@ public class Exports
 * The consuming application for my .NET assembly fails catastrophically if .NET is not installed. How can I improve this UX?
   * For all non-recoverable scenarios, DNNE will call the standard C `abort()` function. This can be overridden by providing your own `dnne_abort()` function. See [`override.c`](./test/ExportingAssembly/override.c) in the [`ExportingAssembly`](./test/ExportingAssembly/ExportingAssembly.csproj) project for an example.
 * How can I add documentation to the exported function in the header file?
-  * Just enable "GenerateDocumentationFile" in the project settings and add some xml documentation to the export function in .NET.
+  * Add the MSBuild property `GenerateDocumentationFile` to the project and the xml documentation on exported C# functions will be added to the generated header file.
 
 # Additional References
 

--- a/readme.md
+++ b/readme.md
@@ -244,6 +244,8 @@ public class Exports
   * The .NET platform provides [`SupportedOSPlatformAttribute`](https://docs.microsoft.com/dotnet/api/system.runtime.versioning.supportedosplatformattribute) and [`UnsupportedOSPlatformAttribute`](https://docs.microsoft.com/dotnet/api/system.runtime.versioning.unsupportedosplatformattribute) which are fully supported by DNNE. All .NET supplied platform names are recognized. It is also possible to define your own using `C99DeclCodeAttribute`. See [`MiscExport.cs`](./test/ExportingAssembly/MiscExports.cs) for an example.
 * The consuming application for my .NET assembly fails catastrophically if .NET is not installed. How can I improve this UX?
   * For all non-recoverable scenarios, DNNE will call the standard C `abort()` function. This can be overridden by providing your own `dnne_abort()` function. See [`override.c`](./test/ExportingAssembly/override.c) in the [`ExportingAssembly`](./test/ExportingAssembly/ExportingAssembly.csproj) project for an example.
+* How can I add documentation to the exported function in the header file?
+  * Just enable "GenerateDocumentationFile" in the project settings and add some xml documentation to the export function in .NET.
 
 # Additional References
 

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -58,7 +58,7 @@ namespace DNNE
         private readonly Scope assemblyScope;
         private readonly Scope moduleScope;
         private readonly IDictionary<TypeDefinitionHandle, Scope> typePlatformScenarios = new Dictionary<TypeDefinitionHandle, Scope>();
-        private Dictionary<string, string> loadedXmlDocumentation = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> loadedXmlDocumentation;
 
         public Generator(string validAssemblyPath)
         {
@@ -313,15 +313,15 @@ namespace DNNE
             var actXml = new Dictionary<string, string>();
             try
             {
-                using (XmlReader xmlReader = XmlReader.Create(xmlDocumentation))
+                // See https://docs.microsoft.com/dotnet/csharp/language-reference/xmldoc/
+                // for xml documenation definition
+                using XmlReader xmlReader = XmlReader.Create(xmlDocumentation);
+                while (xmlReader.Read())
                 {
-                    while (xmlReader.Read())
+                    if (xmlReader.NodeType == XmlNodeType.Element && xmlReader.Name == "member")
                     {
-                        if (xmlReader.NodeType == XmlNodeType.Element && xmlReader.Name == "member")
-                        {
-                            string raw_name = xmlReader["name"];
-                            actXml[raw_name] = xmlReader.ReadInnerXml();
-                        }
+                        string raw_name = xmlReader["name"];
+                        actXml[raw_name] = xmlReader.ReadInnerXml();
                     }
                 }
             }

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -31,6 +31,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml;
 
 namespace DNNE
 {
@@ -57,12 +58,14 @@ namespace DNNE
         private readonly Scope assemblyScope;
         private readonly Scope moduleScope;
         private readonly IDictionary<TypeDefinitionHandle, Scope> typePlatformScenarios = new Dictionary<TypeDefinitionHandle, Scope>();
+        private Dictionary<string, string> loadedXmlDocumentation = new Dictionary<string, string>();
 
         public Generator(string validAssemblyPath)
         {
             this.assemblyPath = validAssemblyPath;
             this.peReader = new PEReader(File.OpenRead(this.assemblyPath));
             this.mdReader = this.peReader.GetMetadataReader(MetadataReaderOptions.None);
+            this.LoadXmlDocumentation(Path.ChangeExtension(validAssemblyPath, "xml"));
 
             // Check for platform scenario attributes
             AssemblyDefinition asmDef = this.mdReader.GetAssemblyDefinition();
@@ -269,6 +272,10 @@ namespace DNNE
                     }
                 }
 
+                var namespaceString = this.mdReader.GetString(typeDef.Namespace);
+                var classString = this.mdReader.GetString(typeDef.Name);
+                var xmlDoc = findXmlDoc(namespaceString + Type.Delimiter + classString + Type.Delimiter + managedMethodName, argumentTypes);
+
                 exportedMethods.Add(new ExportedMethod()
                 {
                     Type = exportAttrType,
@@ -288,6 +295,7 @@ namespace DNNE
                         }
                     },
                     ReturnType = returnType,
+                    XmlDoc = xmlDoc,
                     ArgumentTypes = ImmutableArray.Create(argumentTypes),
                     ArgumentNames = ImmutableArray.Create(argumentNames),
                 });
@@ -300,6 +308,49 @@ namespace DNNE
 
             string assemblyName = this.mdReader.GetString(this.mdReader.GetAssemblyDefinition().Name);
             EmitC99(outputStream, assemblyName, exportedMethods, additionalCodeStatements);
+        }
+
+        public void LoadXmlDocumentation(string xmlDocumentation)
+        {
+            try
+            {
+                using (XmlReader xmlReader = XmlReader.Create(xmlDocumentation))
+                {
+                    while (xmlReader.Read())
+                    {
+                        if (xmlReader.NodeType == XmlNodeType.Element && xmlReader.Name == "member")
+                        {
+                            string raw_name = xmlReader["name"];
+                            loadedXmlDocumentation[raw_name] = xmlReader.ReadInnerXml();
+                        }
+                    }
+                }
+            }
+            catch (FileNotFoundException)
+            {
+            }
+        }
+
+        private string findXmlDoc(string fullMethodName, string[] argumentTypes)
+        {
+            string xmlDoc = "";
+            foreach (var item in loadedXmlDocumentation)
+            {
+                if (item.Key.StartsWith("M:" + fullMethodName + "("))
+                {
+                    xmlDoc = item.Value;
+                    break;
+                }
+            }
+            if (xmlDoc == "") return "";
+
+            var lines = xmlDoc.TrimStart('\n').TrimEnd().Split("\n");
+            string prefix = "/// ";
+            var result = lines
+             .Select(x => prefix + x.Trim())
+             .ToList();
+
+            return Environment.NewLine + string.Join(Environment.NewLine, result);
         }
 
         public void Dispose()
@@ -665,7 +716,7 @@ $@"const char_t* methodName = DNNE_STR(""{export.MethodName}"");
 
                 // Declare export
                 outputStream.WriteLine(
-$@"{preguard}// Computed from {export.EnclosingTypeName}{Type.Delimiter}{export.MethodName}
+$@"{preguard}// Computed from {export.EnclosingTypeName}{Type.Delimiter}{export.MethodName}{export.XmlDoc}
 DNNE_EXTERN_C DNNE_API {export.ReturnType} {callConv} {export.ExportName}({declsig});
 {postguard}");
 
@@ -811,6 +862,7 @@ $@"#endif // {generatedHeaderDefine}
             public SignatureCallingConvention CallingConvention { get; init; }
             public PlatformSupport Platforms { get; init; }
             public string ReturnType { get; init; }
+            public string XmlDoc { get; init; }
             public ImmutableArray<string> ArgumentTypes { get; init; }
             public ImmutableArray<string> ArgumentNames { get; init; }
         }

--- a/src/dnne-gen/Program.cs
+++ b/src/dnne-gen/Program.cs
@@ -36,7 +36,7 @@ namespace DNNE
 
                 var parsed = Parse(args);
 
-                using (var g = new Generator(parsed.AssemblyPath))
+                using (var g = new Generator(parsed.AssemblyPath, parsed.XmlDocFile))
                 {
                     if (string.IsNullOrWhiteSpace(parsed.OutputPath))
                     {
@@ -63,6 +63,7 @@ namespace DNNE
         {
             public string AssemblyPath { get; set; }
             public string OutputPath { get; set; }
+            public string XmlDocFile { get; set; }
         }
 
         class ParseException : Exception
@@ -121,6 +122,20 @@ namespace DNNE
                         parsed.OutputPath = arg;
                         break;
                     }
+                    case "d":
+                    {
+                        if ((i + 1) == args.Length)
+                        {
+                            throw new ParseException(flag, "Missing documentation file");
+                        }
+                        arg = args[++i];
+                        if (!File.Exists(arg))
+                        {
+                            throw new ParseException(arg, "Documentation file not found.");
+                        }
+                        parsed.XmlDocFile = arg;
+                        break;
+                    }
                     case "?":
                     case "help":
                     {
@@ -131,6 +146,10 @@ namespace DNNE
                         it will be overwritten.
                         If not supplied the generated source is
                         written to stdout.
+    -d <xmldocfile>   : The location to the XML documentation file.
+                        This can be activated project properties.
+                        If supplied the comments from the fucntions
+                        are added to the output header file.
     -?              : This message.
 ");
                     }

--- a/src/dnne-gen/Program.cs
+++ b/src/dnne-gen/Program.cs
@@ -148,7 +148,7 @@ namespace DNNE
                         written to stdout.
     -d <xmldocfile>   : The location to the XML documentation file.
                         This can be activated project properties.
-                        If supplied the comments from the fucntions
+                        If supplied the comments from the functions
                         are added to the output header file.
     -?              : This message.
 ");

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -69,7 +69,11 @@ DNNE.targets
     <!-- Ensure the output directory exists -->
     <MakeDir Directories="$(DnneGeneratedOutputPath)" />
 
-    <Exec Command="$(DnneGenExe) @(IntermediateAssembly) -o @(DnneGeneratedSourceFile)" />
+    <PropertyGroup>
+      <DocFlag Condition="Exists($(DocumentationFile))">-d &quot;$(DocumentationFile)&quot;</DocFlag>
+    </PropertyGroup>
+
+    <Exec Command="$(DnneGenExe) @(IntermediateAssembly) $(DocFlag) -o @(DnneGeneratedSourceFile)" />
   </Target>
 
   <PropertyGroup>

--- a/test/ExportingAssembly/ExportingAssembly.csproj
+++ b/test/ExportingAssembly/ExportingAssembly.csproj
@@ -22,6 +22,9 @@
     <DnneCompilerCommand Condition="'$(BuildWithGCC)'=='true'">gcc</DnneCompilerCommand>
     <DnneCompilerCommand Condition="'$(BuildWithGPP)'=='true'">g++</DnneCompilerCommand>
     <DnneCompilerCommand Condition="'$(BuildWithClangPP)'=='true'">clang++</DnneCompilerCommand>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Disable warnings about missing comments -->
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestNuPkg)' == 'true' AND '$(RefLocalBuild)'=='true'">

--- a/test/ExportingAssembly/IntExports.cs
+++ b/test/ExportingAssembly/IntExports.cs
@@ -32,6 +32,11 @@ namespace ExportingAssembly
             return a * 3;
         }
 
+        /// <summary>
+        /// Multiply input value by three
+        /// </summary>
+        /// <param name="a">Input value</param>
+        /// <returns>Result of multiplication</returns>
         [UnmanagedCallersOnly]
         public static int UnmanagedIntInt(int a)
         {

--- a/test/ExportingAssembly/NestedClassExports.cs
+++ b/test/ExportingAssembly/NestedClassExports.cs
@@ -41,11 +41,17 @@ namespace ExportingAssembly
             {
                 public delegate void Nested2_VoidVoidDelegate();
 
+                /// <summary>
+                /// Documentation for Nested2_VoidVoid
+                /// </summary>
                 [DNNE.Export]
                 public static void Nested2_VoidVoid()
                 {
                 }
 
+                /// <summary>
+                /// Documentation for Nested2_UnmanagedVoidVoid
+                /// </summary>
                 [UnmanagedCallersOnly]
                 public static void Nested2_UnmanagedVoidVoid()
                 {


### PR DESCRIPTION
When a xml documentation file is found parallel to the assembly,
this is used to produce code documentation in the C header file.

So just add your XML comments to the function:
```CS
/// <summary>
/// Test documentation
/// </summary>
/// <param name="pString">Pointer to string</param>
/// <returns></returns>
[UnmanagedCallersOnly(EntryPoint = "my_ReleaseString")]
[return: DNNE.C99Type("MyStatusCode")]
public static int ReleaseString([DNNE.C99Type("const char**")] System.IntPtr pString)
```
Enable "XML documentation file" with same file name as assembly with xml extension.
At the moment the path must be set to the intermediate directory (e.g. `obj\Debug\net5.0\ExportingAssembly.xml`)

And the generated header will produce the following `C` header
```C
// Computed from MyWrapper.MyExports.ReleaseString
/// <summary>
/// Test documentation
/// </summary>
/// <param name="pString">Pointer to string</param>
/// <returns></returns>
DNNE_EXTERN_C DNNE_API MyStatusCode DNNE_CALLTYPE my_ReleaseString(const char** pString);
```
