### PR TITLE
fixed type name exception on unsupported method signature types

### DIFF
--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -313,7 +313,7 @@ namespace DNNE
             var actXml = new Dictionary<string, string>();
             if (xmlDocumentation is null)
                 return actXml;
-            
+
             // See https://docs.microsoft.com/dotnet/csharp/language-reference/xmldoc/
             // for xml documenation definition
             using XmlReader xmlReader = XmlReader.Create(xmlDocumentation);
@@ -339,7 +339,7 @@ namespace DNNE
                     break;
                 }
             }
-            if (xmlDoc == "") 
+            if (xmlDoc == "")
                 return "";
 
             var lines = xmlDoc.TrimStart('\n').TrimEnd().Split("\n");
@@ -1045,7 +1045,7 @@ $@"#endif // {generatedHeaderDefine}
                     PrimitiveTypeCode.Single => "float",
                     PrimitiveTypeCode.Double => "double",
                     PrimitiveTypeCode.Void => "void",
-                    _ => throw new NotSupportedTypeException(nameof(typeCode))
+                    _ => throw new NotSupportedTypeException(typeCode.ToString())
                 };
             }
 


### PR DESCRIPTION
i had a 'bool' in my signature, so the gen tool had thrown an exception `Method 'DrvQueryDriverInfo' has non-exportable type 'typeCode'`. With this fix, it now prints `Method 'DrvQueryDriverInfo' has non-exportable type 'Boolean'`