### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build Product and Package
       run: dotnet build src\create_package.proj -c ${{ matrix.flavor }}
     - name: Unit Test Product (cpp)
-      run: dotnet test test\DNNE.UnitTests -c ${{ matrix.flavor }} -p:BuildAsCPP=true
+      run: dotnet test test\DNNE.UnitTests -c ${{ matrix.flavor }} -p:BuildAsCPPWithMSVC=true
     - name: Unit Test Product
       run: |
         dotnet clean test\DNNE.UnitTests -c ${{ matrix.flavor }}

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -788,7 +788,7 @@ $@"#endif // {generatedHeaderDefine}
                         post.Append(" && ");
                     }
 
-                    // Append the "mpsupport" clauses because if they don't exist they are string.Empty
+                    // Append the "nosupport" clauses because if they don't exist they are string.Empty
                     pre.Append($"{pre_nosupport}");
                     post.Append($"{post_nosupport}");
 

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -82,17 +82,17 @@ DNNE.targets
   </PropertyGroup>
 
   <!--
-      Include the compiled binary in the project's None Items so
-      it will flow through project references.
+      Include all output artifacts in the project's None Items so
+      they flow through project references.
   -->
   <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
-    <None Include="$(DnneCompiledToBinPath)">
-      <Link>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</Link>
+    <None Include="@(DnneNativeExportsOutputs->'%(FullPath)')">
+      <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
     <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-      <Link>$(DnneNativeExportsBinaryName).pdb</Link>
+      <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>

--- a/test/DNNE.UnitTests/Consumption.cs
+++ b/test/DNNE.UnitTests/Consumption.cs
@@ -32,20 +32,20 @@ namespace DNNE.UnitTests
         [Fact]
         public void ValidateDnneProjectAssets()
         {
-            string currentAssembly = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string currDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
             // The following native assets are expected to flow with a project reference
             // to a managed project using DNNE to create a native exporting binary.
             string[] assets = new[]
             {
-                Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + GetSystemExtension()),
-                Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + ".h"),
-                Path.Combine(currentAssembly, "dnne.h"),
+                Path.Combine(currDirectory, nameof(ExportingAssembly.ExportingAssemblyNE) + GetSystemExtension()),
+                Path.Combine(currDirectory, nameof(ExportingAssembly.ExportingAssemblyNE) + ".h"),
+                Path.Combine(currDirectory, "dnne.h"),
             };
 
             // On Windows we also propagate the PDB symbols file.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                assets = assets.Append(Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + ".pdb")).ToArray();
+                assets = assets.Append(Path.Combine(currDirectory, nameof(ExportingAssembly.ExportingAssemblyNE) + ".pdb")).ToArray();
 
             foreach (var a in assets)
             {

--- a/test/DNNE.UnitTests/Consumption.cs
+++ b/test/DNNE.UnitTests/Consumption.cs
@@ -18,6 +18,9 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -26,6 +29,39 @@ namespace DNNE.UnitTests
 {
     public class Consumption
     {
+        [Fact]
+        public void ValidateDnneProjectAssets()
+        {
+            string currentAssembly = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            // The following native assets are expected to flow with a project reference
+            // to a managed project using DNNE to create a native exporting binary.
+            string[] assets = new[]
+            {
+                Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + GetSystemExtension()),
+                Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + ".h"),
+                Path.Combine(currentAssembly, "dnne.h"),
+            };
+
+            // On Windows we also propagate the PDB symbols file.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                assets = assets.Append(Path.Combine(currentAssembly, nameof(ExportingAssembly.ExportingAssemblyNE) + ".pdb")).ToArray();
+
+            foreach (var a in assets)
+            {
+                Assert.True(File.Exists(a));
+            }
+
+            static string GetSystemExtension()
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    return ".dll";
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    return ".dylib";
+                return ".so";
+            }
+        }
+
         [Fact]
         public unsafe void FunctionPointerExports()
         {

--- a/test/DNNE.UnitTests/ExportingAssembly.cs
+++ b/test/DNNE.UnitTests/ExportingAssembly.cs
@@ -24,7 +24,7 @@ namespace DNNE.UnitTests
 {
     internal static class ExportingAssembly
     {
-        private static class ExportingAssemblyNE { }
+        public static class ExportingAssemblyNE { }
 
         public unsafe static class FunctionPointerExports
         {

--- a/test/ExportingAssembly/ExportingAssembly.csproj
+++ b/test/ExportingAssembly/ExportingAssembly.csproj
@@ -22,10 +22,13 @@
     <!-- <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers> -->
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
-    <DnneCompilerUserFlags Condition="'$(BuildAsCPP)'=='true'">/TP </DnneCompilerUserFlags>
+    <DnneCompilerUserFlags Condition="'$(BuildAsCPPWithMSVC)'=='true'">/TP </DnneCompilerUserFlags>
     <DnneCompilerCommand Condition="'$(BuildWithGCC)'=='true'">gcc</DnneCompilerCommand>
     <DnneCompilerCommand Condition="'$(BuildWithGPP)'=='true'">g++</DnneCompilerCommand>
     <DnneCompilerCommand Condition="'$(BuildWithClangPP)'=='true'">clang++</DnneCompilerCommand>
+
+    <!-- Include the override option for dnne_abort() -->
+    <DnneCompilerUserFlags>$(DnneCompilerUserFlags)$(MSBuildThisFileDirectory)override.c</DnneCompilerUserFlags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestNuPkg)' == 'true' AND '$(RefLocalBuild)'=='true'">


### PR DESCRIPTION
Add back support for testing `dnne_abort()` and typo.

Enable the flow of native headers to published output. Supersedes https://github.com/AaronRobinsonMSFT/DNNE/pull/117.