### PR TITLE
Fixes 137 and 139

### DIFF
--- a/sample/Exports.cs
+++ b/sample/Exports.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 
 public class Exports
 {
-    [UnmanagedCallersOnlyAttribute(EntryPoint = "FancyName")]
+    [UnmanagedCallersOnly(EntryPoint = "FancyName")]
     public static int MyExport(int a)
     {
         return a;

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DNNE" Version="1.0.32" />
+    <PackageReference Include="DNNE" Version="1.0.33" />
   </ItemGroup>
 
 </Project>

--- a/src/dnne-pkg/dnne-pkg.csproj
+++ b/src/dnne-pkg/dnne-pkg.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PackageId>DNNE</PackageId>
-    <Version>1.0.32</Version>
+    <Version>1.0.33</Version>
     <Authors>AaronRobinsonMSFT</Authors>
     <Owners>AaronRobinsonMSFT</Owners>
     <Description>Package used to generated native exports for .NET assemblies.</Description>

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -97,7 +97,7 @@ namespace DNNE.BuildTasks
             }
 
             // Set linker flags
-            linkerFlags.Append($"/DLL /LTCG ");
+            linkerFlags.Append($"/DLL ");
 
             if (!string.IsNullOrEmpty(exportsDefFile))
             {

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -60,7 +60,7 @@ DNNE.targets
 
   <Target
     Name="DnneGenerateNativeExports"
-    Condition="'$(DnneGenerateExports)' == 'true'"
+    Condition="('$(DesignTimeBuild)' != 'true' OR '$(BuildingProject)' == 'true') AND '$(DnneBuildExports)' == 'true'"
     Inputs="@(IntermediateAssembly)"
     Outputs="@(DnneGeneratedSourceFile)"
     AfterTargets="CoreCompile">


### PR DESCRIPTION
Fixes #137 - Don't generate native export during Design time build
Fixes #139 - Remove unnecessary `/LTCG` linker flag with MSVC