### PR TITLE
Improve UX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ The `preload_runtime()` or `try_preload_runtime()` functions can be used to prel
 
 1) Set the `<EnableDynamicLoading>true</EnableDynamicLoading>` property in the managed project containing the methods to export. This will produce a `*.runtimeconfig.json` that is needed to activate the runtime during export dispatch.
 
-An example C# project can be found in [`Sample`](./sample).
+An example C# project can be found in [`Sample`](./sample). There is also a [native example](./sample/native/main.c), written in C, for consumption options.
 
 ### Native code customization
 
@@ -250,6 +250,8 @@ public class Exports
   * Add the normal triple-slash comments to the exported functions and then set the MSBuild property `GenerateDocumentationFile` to `true` in the project. The compiler will generated xml documentation for the exported C# functions and that will be be added to the generated header file.
 * How can I keep my project cross-platform and generate a native binary for other platforms than the one I am currently building on?
   * The managed assembly will remain cross-platform but the native component is difficult to produce due to native tool chain constraints. In order to accomplish this on the native side, there would need to exist a C99 tool chain that can target any platform from any other platform. For example, the native tool chain could run on Windows but would need to provide a macOS SDK, linux SDK, and produce a macOS `.dylib` (Mach-O image) and/or a linux `.so` (ELF image). If such a native tool chain exists, it would be possible.
+* How can I consume the resulting native binary?
+  * There are two primary options: (1) manually load the binary and discover its exports or (2) directly link against the binary. Both options are discussed in the [native sample](./sample/native/main.c).
 
 # Additional References
 

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DNNE" Version="1.0.33" />
+    <PackageReference Include="DNNE" Version="1.0.34" />
   </ItemGroup>
 
 </Project>

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DNNE" Version="1.0.34" />
+    <PackageReference Include="DNNE" Version="1.0.35" />
   </ItemGroup>
 
 </Project>

--- a/sample/native/main.c
+++ b/sample/native/main.c
@@ -1,0 +1,46 @@
+// Copyright 2023 Aaron R Robinson
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//
+// This example demonstrates how to compile and consume a DNNE generated binary.
+// There are two broad categories.
+//   1) Load the generated native binary (for example, SampleNE.[dll|so|dylib]) via LoadLibrary()/dlopen()
+//      and then lookup the export using GetProcAddress()/dlsym().
+//      See ./test/ImportingProcess for an example using CMake.
+//
+//   2) Include generated header file (for example, SampleNE.h) and link against the export lib on Windows
+//      (for example, SampleNE.lib) or the .so/dylib on Linux/macOS.
+//      For example:
+//          Windows: cl.exe -I ..\bin\Debug\netX.0 main.c /link ..\bin\Debug\netX.0\SampleNE.lib /out:main.exe
+//          Linux/macOS: clang -I ../bin/Debug/netX.0 main.c -o main ../bin/Debug/netX.0/SampleNE.dylib
+//      The above commands will result in a compiled binary. The managed assembly and generated native binary
+//      will need to be copied locally in order to run the scenario.
+//
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <SampleNE.h>
+
+int main(int ac, char** av)
+{
+    printf("Calling managed export\n");
+    int a = FancyName(ac);
+    printf("Called managed with argument count: %d\n", a);
+    return EXIT_SUCCESS;
+}

--- a/src/dnne-gen/Generator.cs
+++ b/src/dnne-gen/Generator.cs
@@ -585,7 +585,13 @@ $@"//
 
 #include <stddef.h>
 #include <stdint.h>
+#ifdef {compileAsSourceDefine}
 #include <dnne.h>
+#else
+// When used as a header file, the assumption is
+// dnne.h will be next to this file.
+#include ""dnne.h""
+#endif // !{compileAsSourceDefine}
 ");
 
             // Emit additional code statements

--- a/src/dnne-pkg/dnne-pkg.csproj
+++ b/src/dnne-pkg/dnne-pkg.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PackageId>DNNE</PackageId>
-    <Version>1.0.34</Version>
+    <Version>1.0.35</Version>
     <Authors>AaronRobinsonMSFT</Authors>
     <Owners>AaronRobinsonMSFT</Owners>
     <Description>Package used to generated native exports for .NET assemblies.</Description>


### PR DESCRIPTION
Use quotes when including the dnne header file in the generated header - this addresses warnings from MSVC.
Add a basic example for how the native binary can be consumed.
Add FAQ entry for how to consume binaries.

Fixes https://github.com/AaronRobinsonMSFT/DNNE/issues/147