### PR TITLE
Make DNNE build incrementally

### DIFF
--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -47,21 +47,34 @@ DNNE.targets
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('OSX'))">.dylib</DnneNativeBinaryExt>
     <DnneNativeBinaryExt Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
 
-    <!-- Compute details about TFM -->
-    <DnneIsNetFramework>false</DnneIsNetFramework>
-    <DnneIsNetFramework Condition="$(TargetFramework.StartsWith('net4'))">true</DnneIsNetFramework>
-    <DnneSupportedTFM>true</DnneSupportedTFM>
-    <DnneSupportedTFM Condition="!$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneIsNetFramework)' == 'true'">false</DnneSupportedTFM>
-
     <DnneCompiledToBinPath>$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
+    <DnneGeneratedSourceFileName>$(DnneGeneratedOutputPath)/$(TargetName).g.c</DnneGeneratedSourceFileName>
   </PropertyGroup>
 
   <ItemGroup>
-    <DnneGeneratedSourceFile Include="$(DnneGeneratedOutputPath)/$(TargetName).g.c" />
-    <DnneNativeExportsOutputs Include="$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt);$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).h;$(DnneNativeExportsBinaryPath)dnne.h" />
+    <DnneGeneratedSourceFile Include="$(DnneGeneratedSourceFileName)" />
+
+    <DnneNativeExportsInput Include="$(DnneCompiledToBinPath)">
+      <OutputFileName>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</OutputFileName>
+    </DnneNativeExportsInput>
+
+    <DnneNativeExportsInput Include="$(DnneGeneratedSourceFileName)" >
+      <OutputFileName>$(DnneNativeExportsBinaryName).h</OutputFileName>
+    </DnneNativeExportsInput>
+
+    <DnneNativeExportsInput Include="$(DnnePlatformSourcePath)/dnne.h" >
+      <OutputFileName>dnne.h</OutputFileName>
+    </DnneNativeExportsInput>
+
+    <!-- Import libs exist only on the Windows platform -->
+    <DnneNativeExportsInput
+        Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
+        Condition="$([MSBuild]::IsOsPlatform('Windows'))" >
+      <OutputFileName>$(DnneNativeExportsBinaryName).lib</OutputFileName>
+    </DnneNativeExportsInput>
 
     <!-- Add outputs and general glob to help with project cleanup -->
-    <Clean Include="@(DnneNativeExportsOutputs);$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
+    <Clean Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
   </ItemGroup>
 
   <Target
@@ -112,8 +125,8 @@ DNNE.targets
   <Target
     Name="DnneBuildNativeExports"
     Condition="('$(DesignTimeBuild)' != 'true' OR '$(BuildingProject)' == 'true') AND '$(DnneSupportedTFM)' == 'true' AND '$(DnneBuildExports)' == 'true'"
-    Inputs="@(DnneGeneratedSourceFile)"
-    Outputs="@(DnneNativeExportsOutputs)"
+    Inputs="@(DnneNativeExportsInput)"
+    Outputs="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')"
     AfterTargets="DnneGenerateNativeExports"
     DependsOnTargets="ResolvePackageAssets;ResolveFrameworkReferences">
     <Message Text="Building native exports binary from @(DnneGeneratedSourceFile)" Importance="$(DnneMSBuildLogging)" />
@@ -173,14 +186,9 @@ DNNE.targets
         Deploy the official 'dnne.h' header.
     -->
     <Copy
-        SourceFiles="$(DnneCompiledToBinPath);$(__DnneGeneratedSourceFile);$(DnnePlatformSourcePath)/dnne.h"
-        DestinationFiles="@(DnneNativeExportsOutputs)" />
+        SourceFiles="@(DnneNativeExportsInput)"
+        DestinationFiles="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')" />
 
-    <!-- Import libs exist only on the Windows platform -->
-    <Copy
-        Condition="$([MSBuild]::IsOsPlatform('Windows'))"
-        SourceFiles="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
-        DestinationFolder="$(DnneNativeExportsBinaryPath)" />
   </Target>
 
   <!--

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -47,6 +47,12 @@ DNNE.targets
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('OSX'))">.dylib</DnneNativeBinaryExt>
     <DnneNativeBinaryExt Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
 
+    <!-- Compute details about TFM -->
+    <DnneIsNetFramework>false</DnneIsNetFramework>
+    <DnneIsNetFramework Condition="$(TargetFramework.StartsWith('net4'))">true</DnneIsNetFramework>
+    <DnneSupportedTFM>true</DnneSupportedTFM>
+    <DnneSupportedTFM Condition="!$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneIsNetFramework)' == 'true'">false</DnneSupportedTFM>
+
     <DnneCompiledToBinPath>$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
     <DnneGeneratedSourceFileName>$(DnneGeneratedOutputPath)/$(TargetName).g.c</DnneGeneratedSourceFileName>
   </PropertyGroup>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -29,37 +29,25 @@ DNNE.targets
 
     <!-- If the user didn't define the name compute one using the legacy mechanism -->
     <DnneNativeBinarySuffix Condition="'$(DnneNativeBinarySuffix)'==''">NE</DnneNativeBinarySuffix>
-    <DnneNativeExportsBinaryName Condition="'$(DnneNativeExportsBinaryName)'==''">
-      $(TargetName)$(DnneNativeBinarySuffix)</DnneNativeExportsBinaryName>
+    <DnneNativeExportsBinaryName Condition="'$(DnneNativeExportsBinaryName)'==''">$(TargetName)$(DnneNativeBinarySuffix)</DnneNativeExportsBinaryName>
     <DnneNativeExportsBinaryPath>$(TargetDir)</DnneNativeExportsBinaryPath>
     <DnneGeneratedOutputPath>$(IntermediateOutputPath)dnne</DnneGeneratedOutputPath>
     <DnneGeneratedBinPath>$(DnneGeneratedOutputPath)/bin</DnneGeneratedBinPath>
 
     <!-- If build was disabled, change the generated output directory to
         where we would have put the compiled binary -->
-    <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">
-      $(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
+    <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">$(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
 
-    <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''">--roll-forward
-      $(DnneGenRollForward)</DnneGenRollForwardFlag>
+    <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
     <DnneGenExe>dotnet $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
     <DnnePlatformSourcePath>$(MSBuildThisFileDirectory)../tools/platform</DnnePlatformSourcePath>
 
     <!-- Compute the extension for the export binary. -->
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('Windows'))">.dll</DnneNativeBinaryExt>
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('OSX'))">.dylib</DnneNativeBinaryExt>
-    <DnneNativeBinaryExt
-      Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
+    <DnneNativeBinaryExt Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
 
-    <!-- Compute details about TFM -->
-    <DnneIsNetFramework>false</DnneIsNetFramework>
-    <DnneIsNetFramework Condition="$(TargetFramework.StartsWith('net4'))">true</DnneIsNetFramework>
-    <DnneSupportedTFM>true</DnneSupportedTFM>
-    <DnneSupportedTFM
-      Condition="!$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneIsNetFramework)' == 'true'">false</DnneSupportedTFM>
-
-    <DnneCompiledToBinPath>
-      $(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
+    <DnneCompiledToBinPath>$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
     <DnneGeneratedSourceFileName>$(DnneGeneratedOutputPath)/$(TargetName).g.c</DnneGeneratedSourceFileName>
   </PropertyGroup>
 
@@ -70,24 +58,23 @@ DNNE.targets
       <OutputFileName>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</OutputFileName>
     </DnneNativeExportsInput>
 
-    <DnneNativeExportsInput Include="$(DnneGeneratedSourceFileName)">
+    <DnneNativeExportsInput Include="$(DnneGeneratedSourceFileName)" >
       <OutputFileName>$(DnneNativeExportsBinaryName).h</OutputFileName>
     </DnneNativeExportsInput>
 
-    <DnneNativeExportsInput Include="$(DnnePlatformSourcePath)/dnne.h">
+    <DnneNativeExportsInput Include="$(DnnePlatformSourcePath)/dnne.h" >
       <OutputFileName>dnne.h</OutputFileName>
     </DnneNativeExportsInput>
 
     <!-- Import libs exist only on the Windows platform -->
     <DnneNativeExportsInput
-      Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
-      Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+        Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
+        Condition="$([MSBuild]::IsOsPlatform('Windows'))" >
       <OutputFileName>$(DnneNativeExportsBinaryName).lib</OutputFileName>
     </DnneNativeExportsInput>
 
     <!-- Add outputs and general glob to help with project cleanup -->
-    <Clean
-      Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*" />
+    <Clean Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
   </ItemGroup>
 
   <Target
@@ -96,8 +83,7 @@ DNNE.targets
     Inputs="@(IntermediateAssembly)"
     Outputs="@(DnneGeneratedSourceFile)"
     AfterTargets="CoreCompile">
-    <Message Text="Generating source for @(IntermediateAssembly) into @(DnneGeneratedSourceFile)"
-      Importance="$(DnneMSBuildLogging)" />
+    <Message Text="Generating source for @(IntermediateAssembly) into @(DnneGeneratedSourceFile)" Importance="$(DnneMSBuildLogging)" />
 
     <!-- Ensure the output directory exists -->
     <MakeDir Directories="$(DnneGeneratedOutputPath)" />
@@ -118,15 +104,13 @@ DNNE.targets
       Include all output artifacts in the project's None Items so
       they flow through project references.
   -->
-  <ItemGroup
-    Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
+  <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
     <None Include="@(DnneNativeExportsOutputs->'%(FullPath)')">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
-    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb"
-      Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
@@ -135,7 +119,7 @@ DNNE.targets
 
   <UsingTask
     TaskName="DNNE.BuildTasks.CreateCompileCommand"
-    AssemblyFile="./$(DnneBuildTasksTFM)/DNNE.BuildTasks.dll"
+    AssemblyFile = "./$(DnneBuildTasksTFM)/DNNE.BuildTasks.dll"
     Condition="'$(DnneBuildExports)' == 'true'" />
 
   <Target
@@ -145,8 +129,7 @@ DNNE.targets
     Outputs="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')"
     AfterTargets="DnneGenerateNativeExports"
     DependsOnTargets="ResolvePackageAssets;ResolveFrameworkReferences">
-    <Message Text="Building native exports binary from @(DnneGeneratedSourceFile)"
-      Importance="$(DnneMSBuildLogging)" />
+    <Message Text="Building native exports binary from @(DnneGeneratedSourceFile)" Importance="$(DnneMSBuildLogging)" />
 
     <Error
       Condition="!Exists(@(DnneGeneratedSourceFile))"
@@ -158,10 +141,8 @@ DNNE.targets
     <PropertyGroup>
       <DnneAssemblyName>$(TargetName)</DnneAssemblyName>
       <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">$(RuntimeIdentifier)</DnneRuntimeIdentifier>
-      <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">
-        $(NETCoreSdkRuntimeIdentifier)</DnneRuntimeIdentifier>
-      <DnneNetHostDir Condition="'$(DnneNetHostDir)' == ''">
-        $(NetCoreTargetingPackRoot)/Microsoft.NETCore.App.Host.$(DnneRuntimeIdentifier)/$(BundledNETCoreAppPackageVersion)/runtimes/$(DnneRuntimeIdentifier)/native</DnneNetHostDir>
+      <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">$(NETCoreSdkRuntimeIdentifier)</DnneRuntimeIdentifier>
+      <DnneNetHostDir Condition="'$(DnneNetHostDir)' == ''">$(NetCoreTargetingPackRoot)/Microsoft.NETCore.App.Host.$(DnneRuntimeIdentifier)/$(BundledNETCoreAppPackageVersion)/runtimes/$(DnneRuntimeIdentifier)/native</DnneNetHostDir>
       <__DnneGeneratedSourceFile>@(DnneGeneratedSourceFile)</__DnneGeneratedSourceFile>
     </PropertyGroup>
 
@@ -170,21 +151,21 @@ DNNE.targets
     </ItemGroup>
 
     <CreateCompileCommand
-      AssemblyName="$(DnneAssemblyName)"
-      NetHostPath="$([MSBuild]::NormalizePath($(DnneNetHostDir)))"
-      PlatformPath="$([MSBuild]::NormalizePath($(DnnePlatformSourcePath)))"
-      Source="$([MSBuild]::NormalizePath($(__DnneGeneratedSourceFile)))"
-      OutputName="$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)"
-      OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
-      RuntimeID="$(DnneRuntimeIdentifier)"
-      Architecture="$(TargetedSDKArchitecture)"
-      Configuration="$(Configuration)"
-      TargetFramework="$(TargetFramework)"
-      ExportsDefFile="$(DnneWindowsExportsDef)"
-      IsSelfContained="$(DnneSelfContained_Experimental)"
-      UserDefinedCompilerFlags="$(DnneCompilerUserFlags)"
-      UserDefinedLinkerFlags="$(DnneLinkerUserFlags)"
-      AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
+        AssemblyName="$(DnneAssemblyName)"
+        NetHostPath="$([MSBuild]::NormalizePath($(DnneNetHostDir)))"
+        PlatformPath="$([MSBuild]::NormalizePath($(DnnePlatformSourcePath)))"
+        Source="$([MSBuild]::NormalizePath($(__DnneGeneratedSourceFile)))"
+        OutputName="$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)"
+        OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
+        RuntimeID="$(DnneRuntimeIdentifier)"
+        Architecture="$(TargetedSDKArchitecture)"
+        Configuration="$(Configuration)"
+        TargetFramework="$(TargetFramework)"
+        ExportsDefFile="$(DnneWindowsExportsDef)"
+        IsSelfContained="$(DnneSelfContained_Experimental)"
+        UserDefinedCompilerFlags="$(DnneCompilerUserFlags)"
+        UserDefinedLinkerFlags="$(DnneLinkerUserFlags)"
+        AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
       <Output TaskParameter="Command" PropertyName="CompilerCmd" />
       <Output TaskParameter="CommandArguments" PropertyName="CompilerArgs" />
     </CreateCompileCommand>
@@ -193,12 +174,11 @@ DNNE.targets
       <CompilerCmd Condition="'$(DnneCompilerCommand)' != ''">$(DnneCompilerCommand)</CompilerCmd>
     </PropertyGroup>
 
-    <Message Text="Building native export: &quot;$(CompilerCmd)&quot; $(CompilerArgs)"
-      Importance="high" />
+    <Message Text="Building native export: &quot;$(CompilerCmd)&quot; $(CompilerArgs)" Importance="high" />
     <Exec Command="&quot;$(CompilerCmd)&quot; $(CompilerArgs)"
-      WorkingDirectory="$(DnneGeneratedOutputPath)"
-      Outputs="$(DnneCompiledToBinPath)"
-      ConsoleToMSBuild="true" />
+        WorkingDirectory="$(DnneGeneratedOutputPath)"
+        Outputs="$(DnneCompiledToBinPath)"
+        ConsoleToMSBuild="true" />
 
     <!--
         Copy the binary to the project output directory.
@@ -206,8 +186,8 @@ DNNE.targets
         Deploy the official 'dnne.h' header.
     -->
     <Copy
-      SourceFiles="@(DnneNativeExportsInput)"
-      DestinationFiles="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')" />
+        SourceFiles="@(DnneNativeExportsInput)"
+        DestinationFiles="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')" />
 
   </Target>
 
@@ -218,18 +198,18 @@ DNNE.targets
     See https://github.com/dotnet/sdk/issues/1675#issuecomment-658779827
   -->
   <Target Name="DnneAddRuntimeDependenciesToContent"
-    BeforeTargets="GetCopyToOutputDirectoryItems"
-    DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles"
-    Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true' AND '$(DnneWorkAroundSdk1675)' == 'true'">
+        BeforeTargets="GetCopyToOutputDirectoryItems"
+        DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles"
+        Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true' AND '$(DnneWorkAroundSdk1675)' == 'true'">
     <ItemGroup>
       <ContentWithTargetPath Include="$(ProjectDepsFilePath)"
-        Condition="'$(GenerateDependencyFile)' == 'true'"
-        CopyToOutputDirectory="PreserveNewest"
-        TargetPath="$(ProjectDepsFileName)" />
+                            Condition="'$(GenerateDependencyFile)' == 'true'"
+                            CopyToOutputDirectory="PreserveNewest"
+                            TargetPath="$(ProjectDepsFileName)" />
       <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
-        Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
-        CopyToOutputDirectory="PreserveNewest"
-        TargetPath="$(ProjectRuntimeConfigFileName)" />
+                            Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
+                            CopyToOutputDirectory="PreserveNewest"
+                            TargetPath="$(ProjectRuntimeConfigFileName)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -29,25 +29,37 @@ DNNE.targets
 
     <!-- If the user didn't define the name compute one using the legacy mechanism -->
     <DnneNativeBinarySuffix Condition="'$(DnneNativeBinarySuffix)'==''">NE</DnneNativeBinarySuffix>
-    <DnneNativeExportsBinaryName Condition="'$(DnneNativeExportsBinaryName)'==''">$(TargetName)$(DnneNativeBinarySuffix)</DnneNativeExportsBinaryName>
+    <DnneNativeExportsBinaryName Condition="'$(DnneNativeExportsBinaryName)'==''">
+      $(TargetName)$(DnneNativeBinarySuffix)</DnneNativeExportsBinaryName>
     <DnneNativeExportsBinaryPath>$(TargetDir)</DnneNativeExportsBinaryPath>
     <DnneGeneratedOutputPath>$(IntermediateOutputPath)dnne</DnneGeneratedOutputPath>
     <DnneGeneratedBinPath>$(DnneGeneratedOutputPath)/bin</DnneGeneratedBinPath>
 
     <!-- If build was disabled, change the generated output directory to
         where we would have put the compiled binary -->
-    <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">$(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
+    <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">
+      $(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
 
-    <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
+    <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''">--roll-forward
+      $(DnneGenRollForward)</DnneGenRollForwardFlag>
     <DnneGenExe>dotnet $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
     <DnnePlatformSourcePath>$(MSBuildThisFileDirectory)../tools/platform</DnnePlatformSourcePath>
 
     <!-- Compute the extension for the export binary. -->
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('Windows'))">.dll</DnneNativeBinaryExt>
     <DnneNativeBinaryExt Condition="$([MSBuild]::IsOsPlatform('OSX'))">.dylib</DnneNativeBinaryExt>
-    <DnneNativeBinaryExt Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
+    <DnneNativeBinaryExt
+      Condition="'$(DnneNativeBinaryExt)' == '' OR $([MSBuild]::IsOsPlatform('Linux'))">.so</DnneNativeBinaryExt>
 
-    <DnneCompiledToBinPath>$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
+    <!-- Compute details about TFM -->
+    <DnneIsNetFramework>false</DnneIsNetFramework>
+    <DnneIsNetFramework Condition="$(TargetFramework.StartsWith('net4'))">true</DnneIsNetFramework>
+    <DnneSupportedTFM>true</DnneSupportedTFM>
+    <DnneSupportedTFM
+      Condition="!$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneIsNetFramework)' == 'true'">false</DnneSupportedTFM>
+
+    <DnneCompiledToBinPath>
+      $(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</DnneCompiledToBinPath>
     <DnneGeneratedSourceFileName>$(DnneGeneratedOutputPath)/$(TargetName).g.c</DnneGeneratedSourceFileName>
   </PropertyGroup>
 
@@ -58,23 +70,24 @@ DNNE.targets
       <OutputFileName>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</OutputFileName>
     </DnneNativeExportsInput>
 
-    <DnneNativeExportsInput Include="$(DnneGeneratedSourceFileName)" >
+    <DnneNativeExportsInput Include="$(DnneGeneratedSourceFileName)">
       <OutputFileName>$(DnneNativeExportsBinaryName).h</OutputFileName>
     </DnneNativeExportsInput>
 
-    <DnneNativeExportsInput Include="$(DnnePlatformSourcePath)/dnne.h" >
+    <DnneNativeExportsInput Include="$(DnnePlatformSourcePath)/dnne.h">
       <OutputFileName>dnne.h</OutputFileName>
     </DnneNativeExportsInput>
 
     <!-- Import libs exist only on the Windows platform -->
     <DnneNativeExportsInput
-        Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
-        Condition="$([MSBuild]::IsOsPlatform('Windows'))" >
+      Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).lib"
+      Condition="$([MSBuild]::IsOsPlatform('Windows'))">
       <OutputFileName>$(DnneNativeExportsBinaryName).lib</OutputFileName>
     </DnneNativeExportsInput>
 
     <!-- Add outputs and general glob to help with project cleanup -->
-    <Clean Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
+    <Clean
+      Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*" />
   </ItemGroup>
 
   <Target
@@ -83,7 +96,8 @@ DNNE.targets
     Inputs="@(IntermediateAssembly)"
     Outputs="@(DnneGeneratedSourceFile)"
     AfterTargets="CoreCompile">
-    <Message Text="Generating source for @(IntermediateAssembly) into @(DnneGeneratedSourceFile)" Importance="$(DnneMSBuildLogging)" />
+    <Message Text="Generating source for @(IntermediateAssembly) into @(DnneGeneratedSourceFile)"
+      Importance="$(DnneMSBuildLogging)" />
 
     <!-- Ensure the output directory exists -->
     <MakeDir Directories="$(DnneGeneratedOutputPath)" />
@@ -104,13 +118,15 @@ DNNE.targets
       Include all output artifacts in the project's None Items so
       they flow through project references.
   -->
-  <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
+  <ItemGroup
+    Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
     <None Include="@(DnneNativeExportsOutputs->'%(FullPath)')">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
-    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb"
+      Condition="$([MSBuild]::IsOsPlatform('Windows'))">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
@@ -119,7 +135,7 @@ DNNE.targets
 
   <UsingTask
     TaskName="DNNE.BuildTasks.CreateCompileCommand"
-    AssemblyFile = "./$(DnneBuildTasksTFM)/DNNE.BuildTasks.dll"
+    AssemblyFile="./$(DnneBuildTasksTFM)/DNNE.BuildTasks.dll"
     Condition="'$(DnneBuildExports)' == 'true'" />
 
   <Target
@@ -129,7 +145,8 @@ DNNE.targets
     Outputs="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')"
     AfterTargets="DnneGenerateNativeExports"
     DependsOnTargets="ResolvePackageAssets;ResolveFrameworkReferences">
-    <Message Text="Building native exports binary from @(DnneGeneratedSourceFile)" Importance="$(DnneMSBuildLogging)" />
+    <Message Text="Building native exports binary from @(DnneGeneratedSourceFile)"
+      Importance="$(DnneMSBuildLogging)" />
 
     <Error
       Condition="!Exists(@(DnneGeneratedSourceFile))"
@@ -141,8 +158,10 @@ DNNE.targets
     <PropertyGroup>
       <DnneAssemblyName>$(TargetName)</DnneAssemblyName>
       <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">$(RuntimeIdentifier)</DnneRuntimeIdentifier>
-      <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">$(NETCoreSdkRuntimeIdentifier)</DnneRuntimeIdentifier>
-      <DnneNetHostDir Condition="'$(DnneNetHostDir)' == ''">$(NetCoreTargetingPackRoot)/Microsoft.NETCore.App.Host.$(DnneRuntimeIdentifier)/$(BundledNETCoreAppPackageVersion)/runtimes/$(DnneRuntimeIdentifier)/native</DnneNetHostDir>
+      <DnneRuntimeIdentifier Condition="'$(DnneRuntimeIdentifier)'==''">
+        $(NETCoreSdkRuntimeIdentifier)</DnneRuntimeIdentifier>
+      <DnneNetHostDir Condition="'$(DnneNetHostDir)' == ''">
+        $(NetCoreTargetingPackRoot)/Microsoft.NETCore.App.Host.$(DnneRuntimeIdentifier)/$(BundledNETCoreAppPackageVersion)/runtimes/$(DnneRuntimeIdentifier)/native</DnneNetHostDir>
       <__DnneGeneratedSourceFile>@(DnneGeneratedSourceFile)</__DnneGeneratedSourceFile>
     </PropertyGroup>
 
@@ -151,21 +170,21 @@ DNNE.targets
     </ItemGroup>
 
     <CreateCompileCommand
-        AssemblyName="$(DnneAssemblyName)"
-        NetHostPath="$([MSBuild]::NormalizePath($(DnneNetHostDir)))"
-        PlatformPath="$([MSBuild]::NormalizePath($(DnnePlatformSourcePath)))"
-        Source="$([MSBuild]::NormalizePath($(__DnneGeneratedSourceFile)))"
-        OutputName="$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)"
-        OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
-        RuntimeID="$(DnneRuntimeIdentifier)"
-        Architecture="$(TargetedSDKArchitecture)"
-        Configuration="$(Configuration)"
-        TargetFramework="$(TargetFramework)"
-        ExportsDefFile="$(DnneWindowsExportsDef)"
-        IsSelfContained="$(DnneSelfContained_Experimental)"
-        UserDefinedCompilerFlags="$(DnneCompilerUserFlags)"
-        UserDefinedLinkerFlags="$(DnneLinkerUserFlags)"
-        AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
+      AssemblyName="$(DnneAssemblyName)"
+      NetHostPath="$([MSBuild]::NormalizePath($(DnneNetHostDir)))"
+      PlatformPath="$([MSBuild]::NormalizePath($(DnnePlatformSourcePath)))"
+      Source="$([MSBuild]::NormalizePath($(__DnneGeneratedSourceFile)))"
+      OutputName="$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)"
+      OutputPath="$([MSBuild]::NormalizePath($(DnneGeneratedBinPath)))"
+      RuntimeID="$(DnneRuntimeIdentifier)"
+      Architecture="$(TargetedSDKArchitecture)"
+      Configuration="$(Configuration)"
+      TargetFramework="$(TargetFramework)"
+      ExportsDefFile="$(DnneWindowsExportsDef)"
+      IsSelfContained="$(DnneSelfContained_Experimental)"
+      UserDefinedCompilerFlags="$(DnneCompilerUserFlags)"
+      UserDefinedLinkerFlags="$(DnneLinkerUserFlags)"
+      AdditionalIncludeDirectories="@(__DnneAdditionalIncludeDirectories)">
       <Output TaskParameter="Command" PropertyName="CompilerCmd" />
       <Output TaskParameter="CommandArguments" PropertyName="CompilerArgs" />
     </CreateCompileCommand>
@@ -174,11 +193,12 @@ DNNE.targets
       <CompilerCmd Condition="'$(DnneCompilerCommand)' != ''">$(DnneCompilerCommand)</CompilerCmd>
     </PropertyGroup>
 
-    <Message Text="Building native export: &quot;$(CompilerCmd)&quot; $(CompilerArgs)" Importance="high" />
+    <Message Text="Building native export: &quot;$(CompilerCmd)&quot; $(CompilerArgs)"
+      Importance="high" />
     <Exec Command="&quot;$(CompilerCmd)&quot; $(CompilerArgs)"
-        WorkingDirectory="$(DnneGeneratedOutputPath)"
-        Outputs="$(DnneCompiledToBinPath)"
-        ConsoleToMSBuild="true" />
+      WorkingDirectory="$(DnneGeneratedOutputPath)"
+      Outputs="$(DnneCompiledToBinPath)"
+      ConsoleToMSBuild="true" />
 
     <!--
         Copy the binary to the project output directory.
@@ -186,8 +206,8 @@ DNNE.targets
         Deploy the official 'dnne.h' header.
     -->
     <Copy
-        SourceFiles="@(DnneNativeExportsInput)"
-        DestinationFiles="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')" />
+      SourceFiles="@(DnneNativeExportsInput)"
+      DestinationFiles="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')" />
 
   </Target>
 
@@ -198,18 +218,18 @@ DNNE.targets
     See https://github.com/dotnet/sdk/issues/1675#issuecomment-658779827
   -->
   <Target Name="DnneAddRuntimeDependenciesToContent"
-        BeforeTargets="GetCopyToOutputDirectoryItems"
-        DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles"
-        Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true' AND '$(DnneWorkAroundSdk1675)' == 'true'">
+    BeforeTargets="GetCopyToOutputDirectoryItems"
+    DependsOnTargets="GenerateBuildDependencyFile;GenerateBuildRuntimeConfigurationFiles"
+    Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true' AND '$(DnneWorkAroundSdk1675)' == 'true'">
     <ItemGroup>
       <ContentWithTargetPath Include="$(ProjectDepsFilePath)"
-                            Condition="'$(GenerateDependencyFile)' == 'true'"
-                            CopyToOutputDirectory="PreserveNewest"
-                            TargetPath="$(ProjectDepsFileName)" />
+        Condition="'$(GenerateDependencyFile)' == 'true'"
+        CopyToOutputDirectory="PreserveNewest"
+        TargetPath="$(ProjectDepsFileName)" />
       <ContentWithTargetPath Include="$(ProjectRuntimeConfigFilePath)"
-                            Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
-                            CopyToOutputDirectory="PreserveNewest"
-                            TargetPath="$(ProjectRuntimeConfigFileName)" />
+        Condition="'$(GenerateRuntimeConfigurationFiles)' == 'true'"
+        CopyToOutputDirectory="PreserveNewest"
+        TargetPath="$(ProjectRuntimeConfigFileName)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -111,7 +111,7 @@ DNNE.targets
       they flow through project references.
   -->
   <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
-    <None Include="@(DnneNativeExportsOutputs->'%(FullPath)')">
+    <None Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>


### PR DESCRIPTION
MSBuild is annoying and this is required to build incrementally. MSBuild will compare the oldest output to the newest input by default, and `dnne.h` from the nuget package is always going to be older than the generated header, so it'll never build incrementally. We need to create a 1:1 mapping from input item to output item, but this can ONLY be done when the output property is a transformation of the input https://github.com/dotnet/msbuild/issues/7021.

All of the output filenames are the same except for `DnneGeneratedSourceFile`. If we change that to `$(DnneNativeExportsBinaryName).h` (binaryname.h) instead of `$(DnneGeneratedOutputPath)/$(TargetName).g.c` we could make it a bit simpler by avoiding the extra "OutputFileName" metadata.
