### PR TITLE
Add -Wno-atomic-align

### DIFF
--- a/src/msbuild/DNNE.BuildTasks/macOS.cs
+++ b/src/msbuild/DNNE.BuildTasks/macOS.cs
@@ -69,7 +69,8 @@ namespace DNNE.BuildTasks
             compilerFlags.Append($"\"{export.Source}\" \"{Path.Combine(export.PlatformPath, "platform.c")}\" ");
             compilerFlags.Append($"-lstdc++ ");
             compilerFlags.Append($"\"{Path.Combine(export.NetHostPath, "libnethost.a")}\" ");
-
+            compilerFlags.Append("-Wno-atomic-alignment");
+            
             if (!string.IsNullOrEmpty(export.UserDefinedLinkerFlags))
             {
                 compilerFlags.Append($"{export.UserDefinedLinkerFlags} ");


### PR DESCRIPTION
On Linux arm dotnet/runtime builds, this atomic instruction in platform.c warns. 

https://github.com/AaronRobinsonMSFT/DNNE/blob/3657e77c4a988054ea8c0a84122b5bb450503b49/src/platform/platform.c#L298-L301

To silence the warning, use "-Wno-atomic-alignment" for clang.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=354415&view=logs&j=fbba4562-0196-5144-0bc8-97e5ecde48bd&t=965fe576-127f-568f-354c-a3511c13c4cb&l=2414

I haven't yet confirmed this change fixes the issue.