### PR TITLE
Tests and warnings

### DIFF
--- a/test/DNNE.UnitTests/Consumption.cs
+++ b/test/DNNE.UnitTests/Consumption.cs
@@ -92,7 +92,7 @@ namespace DNNE.UnitTests
 
             Assert.Equal(num, ExportingAssembly.InstanceExports.MyClass_getNumber(inst));
 
-            ExportingAssembly.InstanceExports.MyClass_printNumber(inst);
+            Assert.Equal(num * 2, ExportingAssembly.InstanceExports.MyClass_doubleNumber(inst));
             ExportingAssembly.InstanceExports.MyClass_dtor(inst);
         }
 

--- a/test/DNNE.UnitTests/ExportingAssembly.cs
+++ b/test/DNNE.UnitTests/ExportingAssembly.cs
@@ -56,7 +56,7 @@ namespace DNNE.UnitTests
             public static extern void MyClass_setNumber(IntPtr inst, int number);
 
             [DllImport(nameof(ExportingAssemblyNE))]
-            public static extern void MyClass_printNumber(IntPtr inst);
+            public static extern int MyClass_doubleNumber(IntPtr inst);
         }
 
         public static class IntExports

--- a/test/ExportingAssembly/ExportingAssembly.csproj
+++ b/test/ExportingAssembly/ExportingAssembly.csproj
@@ -7,7 +7,8 @@
   <Import Condition="'$(TestNuPkg)' != 'true'" Project="$(PseudoPackage)build/DNNE.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RollForward>Major</RollForward>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -22,7 +23,7 @@
     <DnneCompilerCommand Condition="'$(BuildWithClangPP)'=='true'">clang++</DnneCompilerCommand>
 
     <!-- Include the override option for dnne_abort() -->
-    <DnneCompilerUserFlags>$(DnneCompilerUserFlags)$(MSBuildThisFileDirectory)override.c</DnneCompilerUserFlags>
+    <DnneCompilerUserFlags>$(DnneCompilerUserFlags) $(MSBuildThisFileDirectory)override.c</DnneCompilerUserFlags>
 
     <!-- When targeting .NET Framework we only use a subset of files -->
     <EnableDefaultCompileItems Condition="$(TargetFramework.StartsWith('net4'))">false</EnableDefaultCompileItems>

--- a/test/ExportingAssembly/InstanceExports.cs
+++ b/test/ExportingAssembly/InstanceExports.cs
@@ -38,7 +38,7 @@ namespace ExportingAssembly
     /// class MyClass
     /// {
     ///     intptr_t _inst;
-    /// 
+    ///
     /// public:
     ///     MyClass()
     ///     {
@@ -56,9 +56,9 @@ namespace ExportingAssembly
     ///     {
     ///         MyClass_setNumber(_inst, num);
     ///     }
-    ///     void printNumber()
+    ///     int32_t doubleNumber()
     ///     {
-    ///         MyClass_printNumber(_inst);
+    ///         return MyClass_doubleNumber(_inst);
     ///     }
     ///     // Delete copy functions since a copy export isn't defined.
     ///     MyClass(const MyClass&) = delete;
@@ -94,10 +94,10 @@ namespace ExportingAssembly
             As<MyClass>(inst).Number = number;
         }
 
-        [UnmanagedCallersOnly(EntryPoint = "MyClass_printNumber")]
-        public static void MyClassPrintNumber(IntPtr inst)
+        [UnmanagedCallersOnly(EntryPoint = "MyClass_doubleNumber")]
+        public static int MyClassDoubleNumber(IntPtr inst)
         {
-            As<MyClass>(inst).PrintNumber();
+            return As<MyClass>(inst).DoubleNumber();
         }
 
         private static T As<T>(IntPtr ptr) where T : class
@@ -111,15 +111,12 @@ namespace ExportingAssembly
     /// </summary>
     public class MyClass
     {
-        private int number;
-
         public MyClass()
         {
-            this.number = 0;
         }
 
         public int Number { get; set; }
 
-        public void PrintNumber() => Console.WriteLine(this.number);
+        public int DoubleNumber() => 2 * this.Number;
     }
 }


### PR DESCRIPTION
Address warnings on arm.

Convert to using [`__atomic_compare_exchange_n`](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html) from [`__sync_val_compare_and_swap`](https://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html).

Update instance test to not print to console and instead return so validation is possible.

Supersedes https://github.com/AaronRobinsonMSFT/DNNE/pull/173

/cc @jtschuster @jkoritzinsky 