### PR TITLE
fix: If GetCurrentAppDomainId fails try GetDefaultDomain first (.netframework remote start issue)

### DIFF
--- a/DNNE.sln
+++ b/DNNE.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "platform", "platform", "{95
 	ProjectSection(SolutionItems) = preProject
 		src\platform\dnne.h = src\platform\dnne.h
 		src\platform\platform.c = src\platform\platform.c
+		src\platform\platform_v4.cpp = src\platform\platform_v4.cpp
 	EndProjectSection
 EndProject
 Global

--- a/src/platform/platform_v4.cpp
+++ b/src/platform/platform_v4.cpp
@@ -163,6 +163,8 @@ namespace
             hr = runtimeHost->GetCurrentAppDomainId(&_appDomainId);
 	    if (hr != S_OK)
             {
+                // This is a fallback attempt if the runtime is already activated
+                // and this thread isn't the one that did that work.
                 ICorRuntimeHost* oldRuntimeHost;
                 hr = runtimeInfo->GetInterface(CLSID_CorRuntimeHost, IID_ICorRuntimeHost, (void**)&oldRuntimeHost);
                 IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);

--- a/src/platform/platform_v4.cpp
+++ b/src/platform/platform_v4.cpp
@@ -155,13 +155,25 @@ namespace
 
             // Release all other CLR resources
             (void)metahost->Release();
-            (void)runtimeInfo->Release();
 
             // Start the runtime
             hr = runtimeHost->Start();
             IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
 
-            (void)runtimeHost->GetCurrentAppDomainId(&_appDomainId);
+            hr = runtimeHost->GetCurrentAppDomainId(&_appDomainId);
+	    if (hr != S_OK)
+            {
+                ICorRuntimeHost* oldRuntimeHost;
+                hr = runtimeInfo->GetInterface(CLSID_CorRuntimeHost, IID_ICorRuntimeHost, (void**)&oldRuntimeHost);
+                IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
+                IUnknown* pUnk2;
+                hr = oldRuntimeHost->GetDefaultDomain(&pUnk2);
+                IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
+                hr = runtimeHost->GetCurrentAppDomainId(&_appDomainId);
+            }
+            (void)runtimeInfo->Release(); //can't release earlier incase backup failure
+
+            IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
             (void)runtimeHost->QueryInterface(__uuidof(ICLRPrivRuntime), (void**)&_host);
             (void)runtimeHost->Release();
             assert(_host != nullptr);

--- a/src/platform/platform_v4.cpp
+++ b/src/platform/platform_v4.cpp
@@ -161,16 +161,21 @@ namespace
             IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
 
             hr = runtimeHost->GetCurrentAppDomainId(&_appDomainId);
-	    if (hr != S_OK)
+            if (hr != S_OK)
             {
                 // This is a fallback attempt if the runtime is already activated
-                // and this thread isn't the one that did that work.
+                // and this thread isn't known to the runtime.
                 ICorRuntimeHost* oldRuntimeHost;
                 hr = runtimeInfo->GetInterface(CLSID_CorRuntimeHost, IID_ICorRuntimeHost, (void**)&oldRuntimeHost);
                 IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
                 IUnknown* pUnk2;
                 hr = oldRuntimeHost->GetDefaultDomain(&pUnk2);
                 IF_FAILURE_RETURN_OR_ABORT(ret, failure_load_runtime, hr, &_prepare_lock);
+
+                // Release resources.
+                (void)pUnk2->Release();
+                (void)oldRuntimeHost->Release();
+
                 hr = runtimeHost->GetCurrentAppDomainId(&_appDomainId);
             }
             (void)runtimeInfo->Release(); //can't release earlier incase backup failure


### PR DESCRIPTION
Thanks for a fantastic library!
This does 3 things, if you want it split into 3 commits let me know:
- Adds the cpp platform to the solution/project as it is what is generally used anyway
- Checks the result of GetCurrentAppDomain() call, for whatever reason the result was ignored before, maybe to default to 0 incase of failure, but this can lead to startup aborts later when the appdomain is incorrect (adds a few more error states as well)
- Fix an issue with loading in a .net framework application via a new remote thread.   I found GetCurrentAppDomain would fail and couldn't find a good way to fix this.  The other calls all succeeded.  I did find that if I called GetDefaultDomain on the old runtime interface this would fix it so the call would then succeed.  Technically if we import the AppDomain type we could pull the id right off of the result from GetDefaultDomain but not sure its needed.    This should only change the hotpath for previous where the code would gloriously fail before (well assuming the appdomain was not 0, but the more commonly 1 for .net framework apps anyway).