### PR TITLE
Use DOTNET_HOST_PATH instead of hardcoded dotnet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This work is inspired by work in the [Xamarin][xamarin_embed_link], [CoreRT][cor
 
 ### Minimum
 
-* [.NET 6.0](https://dotnet.microsoft.com/download) or greater.
+* [.NET 8.0](https://dotnet.microsoft.com/download) or greater.
 * [C99](https://en.cppreference.com/w/c/language/history) compatible compiler.
 
 ### DNNE NuPkg Requirements

--- a/sample/Sample.csproj
+++ b/sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <DnneNativeBinaryName>sample_native</DnneNativeBinaryName>
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>

--- a/src/dnne-gen/dnne-gen.csproj
+++ b/src/dnne-gen/dnne-gen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>DNNE</RootNamespace>
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/src/dnne-pkg/dnne-pkg.csproj
+++ b/src/dnne-pkg/dnne-pkg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>dnne_pkg</RootNamespace>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <PseudoPackageDir>../pkg/</PseudoPackageDir>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -41,7 +41,7 @@ DNNE.targets
     <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">$(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
 
     <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
-    <!-- Provide a way to define the host path -->
+    <!-- Respect the official way to define the host path -->
     <DnneDotnetHostPath>$(DOTNET_HOST_PATH)</DnneDotnetHostPath>
     <DnneDotnetHostPath Condition="'$(DnneDotnetHostPath)' == ''">dotnet</DnneDotnetHostPath>
     <DnneGenExe>"$(DnneDotnetHostPath)" $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -41,9 +41,10 @@ DNNE.targets
     <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">$(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
 
     <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
-    <_hostPath>$(DOTNET_HOST_PATH)</_hostPath>
-    <_hostPath Condition="'$(_hostPath)' == ''">dotnet</_hostPath> <!-- fallback when building with desktop msbuild -->
-    <DnneGenExe>"$(_hostPath)" $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
+    <!-- Provide a way to define the host path -->
+    <DnneDotnetHostPath>$(DOTNET_HOST_PATH)</DnneDotnetHostPath>
+    <DnneDotnetHostPath Condition="'$(DnneDotnetHostPath)' == ''">dotnet</DnneDotnetHostPath>
+    <DnneGenExe>"$(DnneDotnetHostPath)" $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
     <DnnePlatformSourcePath>$(MSBuildThisFileDirectory)../tools/platform</DnnePlatformSourcePath>
 
     <!-- Compute the extension for the export binary. -->

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -43,7 +43,7 @@ DNNE.targets
     <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
     <_hostPath>$(DOTNET_HOST_PATH)</_hostPath>
     <_hostPath Condition="'$(_hostPath)' == ''">dotnet</_hostPath> <!-- fallback when building with desktop msbuild -->
-    <DnneGenExe>&quot;$(_hostPath)&quot; $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
+    <DnneGenExe>"$(_hostPath)" $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
     <DnnePlatformSourcePath>$(MSBuildThisFileDirectory)../tools/platform</DnnePlatformSourcePath>
 
     <!-- Compute the extension for the export binary. -->

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -41,7 +41,9 @@ DNNE.targets
     <DnneGeneratedOutputPath Condition="'$(DnneBuildExports)' != 'true'">$(DnneNativeExportsBinaryPath)</DnneGeneratedOutputPath>
 
     <DnneGenRollForwardFlag Condition="'$(DnneGenRollForward)' != ''" >--roll-forward $(DnneGenRollForward)</DnneGenRollForwardFlag>
-    <DnneGenExe>dotnet $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
+    <_hostPath>$(DOTNET_HOST_PATH)</_hostPath>
+    <_hostPath Condition="'$(_hostPath)' == ''">dotnet</_hostPath> <!-- fallback when building with desktop msbuild -->
+    <DnneGenExe>&quot;$(_hostPath)&quot; $(DnneGenRollForwardFlag) "$(MSBuildThisFileDirectory)../tools/dnne-gen.dll"</DnneGenExe>
     <DnnePlatformSourcePath>$(MSBuildThisFileDirectory)../tools/platform</DnnePlatformSourcePath>
 
     <!-- Compute the extension for the export binary. -->

--- a/test/DNNE.UnitTests/DNNE.UnitTests.csproj
+++ b/test/DNNE.UnitTests/DNNE.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/ExportingAssembly/ExportingAssembly.csproj
+++ b/test/ExportingAssembly/ExportingAssembly.csproj
@@ -11,7 +11,7 @@
   <Import Condition="'$(TestNuPkg)' != 'true'" Project="$(PseudoPackage)build/DNNE.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RollForward>Major</RollForward>


### PR DESCRIPTION
* Use `$(DOTNET_HOST_PATH)` when available, instead of hardcoded dotnet.exe.
* Update to net8.0 LTS, since net6.0 is out of support.