### PR TITLE
Publish NE .dll

### DIFF
--- a/src/msbuild/DNNE.props
+++ b/src/msbuild/DNNE.props
@@ -24,10 +24,12 @@ DNNE.props
 -->
 <Project>
   <PropertyGroup>
+    <!-- When true, generates the header source files for compiling against the exports -->
     <DnneGenerateExports>true</DnneGenerateExports>
 
     <!-- If the build is disabled, the generated source is considered the output
         and emitted in the output directory as if it were a binary. -->
+    <!-- When true, builds the DNNE native binary (ProjectNameNE.dll) -->
     <DnneBuildExports>true</DnneBuildExports>
 
     <!-- The name of the resulting native binary. This should be the name of the binary
@@ -42,7 +44,9 @@ DNNE.props
     <!-- Logging level passed to output from the DNNE build process. -->
     <DnneMSBuildLogging>low</DnneMSBuildLogging>
 
-    <!-- Add the generated binary to the project contents -->
+    <!-- When true, adds the files produced by DNNE to the project output path and flow them
+        through ProjectReferences. May include only the headers or only the native binary
+        files depending on DnneBuildExports and DnneGenerateExports. -->
     <DnneAddGeneratedBinaryToProject>false</DnneAddGeneratedBinaryToProject>
 
     <!-- Enable a workaround for https://github.com/dotnet/sdk/issues/1675 -->

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -92,6 +92,10 @@ DNNE.targets
       <OutputFileName>$(DnneNativeExportsBinaryName).lib</OutputFileName>
     </DnneNativeExportsInput>
 
+    <ResolvedFileToPublish Include="$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)">
+      <RelativePath>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</RelativePath>
+    </ResolvedFileToPublish>
+
     <!-- Add outputs and general glob to help with project cleanup -->
     <Clean Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
   </ItemGroup>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -123,14 +123,14 @@ DNNE.targets
       Include all output artifacts in the project's None Items so
       they flow through project references.
   -->
-  <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
-    <Content Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')">
+  <ItemGroup Condition="'$(DnneAddGeneratedBinaryToProject)' == 'true'">
+    <None Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')">
       <Link>%(Filename)%(Extension)</Link>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <PublishState>Included</PublishState>
-    </Content>
+    </None>
     <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneBuildExports)' == 'true'">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/msbuild/DNNE.targets
+++ b/src/msbuild/DNNE.targets
@@ -92,10 +92,6 @@ DNNE.targets
       <OutputFileName>$(DnneNativeExportsBinaryName).lib</OutputFileName>
     </DnneNativeExportsInput>
 
-    <ResolvedFileToPublish Include="$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)">
-      <RelativePath>$(DnneNativeExportsBinaryName)$(DnneNativeBinaryExt)</RelativePath>
-    </ResolvedFileToPublish>
-
     <!-- Add outputs and general glob to help with project cleanup -->
     <Clean Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)');$(DnneNativeExportsBinaryPath)$(DnneNativeExportsBinaryName).*"/>
   </ItemGroup>
@@ -128,12 +124,14 @@ DNNE.targets
       they flow through project references.
   -->
   <ItemGroup Condition="'$(DnneBuildExports)' == 'true' AND '$(DnneAddGeneratedBinaryToProject)' == 'true'">
-    <None Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')">
+    <Content Include="@(DnneNativeExportsInput->'$(DnneNativeExportsBinaryPath)%(OutputFileName)')">
       <Link>%(Filename)%(Extension)</Link>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
-    </None>
-    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+      <PublishState>Included</PublishState>
+    </Content>
+    <None Include="$(DnneGeneratedBinPath)/$(DnneNativeExportsBinaryName).pdb" Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$(DnneBuildExports)' == 'true'">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>


### PR DESCRIPTION
The native exports library doesn't get copied to the publish folder by default, so this adds it to an itemgroup to do that.

Should the .c, .h, and .lib folders also be published?