### PR TITLE
Fix hard-coded Hostx64 path to support arm64 and x86 hosts

### DIFF
--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -176,17 +176,7 @@ namespace DNNE.BuildTasks
         private static string GetVCHostBinDir(string vcToolDir, string archDir)
         {
             // Determine the preferred host directory based on the current process architecture.
-            string preferredHostDir = RuntimeInformation.ProcessArchitecture switch
-            {
-                Architecture.X64 => "Hostx64",
-                Architecture.X86 => "Hostx86",
-                Architecture.Arm64 => "HostArm64",
-                _ => null
-            };
-
-            // Try the preferred host first, then fall back to other hosts in priority order.
-            string[] fallbackHostDirs = new[] { "HostArm64", "Hostx64", "Hostx86" };
-
+            string preferredHostDir = HostSubDirectory(RuntimeInformation.ProcessArchitecture);
             if (preferredHostDir != null)
             {
                 string preferredPath = Path.Combine(vcToolDir, "bin", preferredHostDir, archDir);
@@ -196,7 +186,8 @@ namespace DNNE.BuildTasks
                 }
             }
 
-            foreach (var hostDir in fallbackHostDirs)
+            // Fall back to other hosts in priority order.
+            foreach (var hostDir in new[] { Architecture.Arm64, Architecture.X64, Architecture.X86 })
             {
                 // Skip the preferred host since we already tried it.
                 if (hostDir == preferredHostDir)
@@ -210,6 +201,17 @@ namespace DNNE.BuildTasks
             }
 
             throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", fallbackHostDirs)} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
+
+            static string HostSubDirectory(Architecture arch)
+            {
+                return arch switch
+                {
+                    Architecture.X64 => "Hostx64",
+                    Architecture.X86 => "Hostx86",
+                    Architecture.Arm64 => "HostArm64",
+                    _ => null
+                };
+            }
         }
 
 

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -53,14 +53,7 @@ namespace DNNE.BuildTasks
             var vcIncDir = Path.Combine(vcToolDir, "include");
             var libDir = Path.Combine(vcToolDir, "lib", archDir);
 
-            var hostDir = RuntimeInformation.ProcessArchitecture switch
-            {
-                Architecture.X64 => "Hostx64",
-                Architecture.X86 => "Hostx86",
-                Architecture.Arm64 => "HostArm64",
-                _ => throw new Exception($"Unsupported host architecture: {RuntimeInformation.ProcessArchitecture}")
-            };
-            var binDir = Path.Combine(vcToolDir, "bin", hostDir, archDir);
+            var binDir = GetVCHostBinDir(vcToolDir, archDir);
 
             string compileAsFlag;
             string hostLib;
@@ -179,6 +172,46 @@ namespace DNNE.BuildTasks
             command = Path.Combine(binDir, "cl.exe");
             commandArguments = $"{compilerFlags} \"{export.Source}\" \"{platformTU}\" /link {linkerFlags}";
         }
+
+        private static string GetVCHostBinDir(string vcToolDir, string archDir)
+        {
+            // Determine the preferred host directory based on the current process architecture.
+            string preferredHostDir = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "Hostx64",
+                Architecture.X86 => "Hostx86",
+                Architecture.Arm64 => "HostArm64",
+                _ => null
+            };
+
+            // Try the preferred host first, then fall back to other hosts in priority order.
+            string[] fallbackHostDirs = new[] { "HostArm64", "Hostx64", "Hostx86" };
+
+            if (preferredHostDir != null)
+            {
+                string preferredPath = Path.Combine(vcToolDir, "bin", preferredHostDir, archDir);
+                if (Directory.Exists(preferredPath))
+                {
+                    return preferredPath;
+                }
+            }
+
+            foreach (var hostDir in fallbackHostDirs)
+            {
+                // Skip the preferred host since we already tried it.
+                if (hostDir == preferredHostDir)
+                    continue;
+
+                string candidatePath = Path.Combine(vcToolDir, "bin", hostDir, archDir);
+                if (Directory.Exists(candidatePath))
+                {
+                    return candidatePath;
+                }
+            }
+
+            throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", fallbackHostDirs)} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
+        }
+
 
         private static string ConvertToVCArchSubDir(string arch, string rid)
         {

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -187,13 +187,13 @@ namespace DNNE.BuildTasks
             }
 
             // Fall back to other hosts in priority order.
-            foreach (var hostDir in new[] { Architecture.Arm64, Architecture.X64, Architecture.X86 })
+            foreach (var tgtArch in new[] { Architecture.Arm64, Architecture.X64, Architecture.X86 })
             {
                 // Skip the preferred host since we already tried it.
-                if (hostDir == preferredHostDir)
+                if (tgtArch == RuntimeInformation.ProcessArchitecture)
                     continue;
 
-                string candidatePath = Path.Combine(vcToolDir, "bin", hostDir, archDir);
+                string candidatePath = Path.Combine(vcToolDir, "bin", HostSubDirectory(tgtArch), archDir);
                 if (Directory.Exists(candidatePath))
                 {
                     return candidatePath;

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -205,9 +205,7 @@ namespace DNNE.BuildTasks
                 consideredPaths.Add(hostDir);
             }
 
-            
-
-            throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", consideredPaths} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
+            throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", consideredPaths)} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
 
             static string HostSubDirectory(Architecture arch)
             {

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -57,7 +57,7 @@ namespace DNNE.BuildTasks
             {
                 Architecture.X64 => "Hostx64",
                 Architecture.X86 => "Hostx86",
-                Architecture.Arm64 => "Hostarm64",
+                Architecture.Arm64 => "HostArm64",
                 _ => throw new Exception($"Unsupported host architecture: {RuntimeInformation.ProcessArchitecture}")
             };
             var binDir = Path.Combine(vcToolDir, "bin", hostDir, archDir);

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -214,7 +214,6 @@ namespace DNNE.BuildTasks
             }
         }
 
-
         private static string ConvertToVCArchSubDir(string arch, string rid)
         {
             return arch.ToLower() switch

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -53,8 +53,14 @@ namespace DNNE.BuildTasks
             var vcIncDir = Path.Combine(vcToolDir, "include");
             var libDir = Path.Combine(vcToolDir, "lib", archDir);
 
-            // For now we assume building always happens on a x64 machine.
-            var binDir = Path.Combine(vcToolDir, "bin\\Hostx64", archDir);
+            var hostDir = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "Hostx64",
+                Architecture.X86 => "Hostx86",
+                Architecture.Arm64 => "Hostarm64",
+                _ => throw new Exception($"Unsupported host architecture: {RuntimeInformation.ProcessArchitecture}")
+            };
+            var binDir = Path.Combine(vcToolDir, "bin", hostDir, archDir);
 
             string compileAsFlag;
             string hostLib;

--- a/src/msbuild/DNNE.BuildTasks/Windows.cs
+++ b/src/msbuild/DNNE.BuildTasks/Windows.cs
@@ -187,20 +187,27 @@ namespace DNNE.BuildTasks
             }
 
             // Fall back to other hosts in priority order.
-            foreach (var tgtArch in new[] { Architecture.Arm64, Architecture.X64, Architecture.X86 })
+            List<string> consideredPaths = new();
+            var fallbackHostArchs = new[] { Architecture.Arm64, Architecture.X64, Architecture.X86 };
+            foreach (var tgtArch in fallbackHostArchs)
             {
                 // Skip the preferred host since we already tried it.
                 if (tgtArch == RuntimeInformation.ProcessArchitecture)
                     continue;
 
-                string candidatePath = Path.Combine(vcToolDir, "bin", HostSubDirectory(tgtArch), archDir);
+                string hostDir = HostSubDirectory(tgtArch);
+                string candidatePath = Path.Combine(vcToolDir, "bin", hostDir, archDir);
                 if (Directory.Exists(candidatePath))
                 {
                     return candidatePath;
                 }
+
+                consideredPaths.Add(hostDir);
             }
 
-            throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", fallbackHostDirs)} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
+            
+
+            throw new Exception($"No VC host compiler directory found. Searched: {string.Join(", ", consideredPaths} under '{Path.Combine(vcToolDir, "bin")}' for target '{archDir}'.");
 
             static string HostSubDirectory(Architecture arch)
             {


### PR DESCRIPTION
The hardcoded path of `bin\Hostx64` is causing some dotnet/runtime pipelines to fail: https://github.com/dotnet/runtime/issues/126673

Switch over the current host architecture to determine the bin directory