### PR TITLE
Fix FreeBSD export name typo (OnlyOnFreeSBD)

### DIFF
--- a/test/ExportingAssembly/MiscExports.cs
+++ b/test/ExportingAssembly/MiscExports.cs
@@ -76,7 +76,7 @@ namespace ExportingAssembly
 
         [UnmanagedCallersOnly]
         [SupportedOSPlatform("freebsd")]
-        public static void OnlyOnFreeSBD()
+        public static void OnlyOnFreeBSD()
         {
         }
 


### PR DESCRIPTION
## Summary
- Rename `OnlyOnFreeSBD` to `OnlyOnFreeBSD` so the managed export symbol matches the unit-test P/Invoke declaration.
- Without an `EntryPoint`, dnne-gen uses the managed method name as the native export; the typo made the FreeBSD-only export unresolvable on FreeBSD (hidden today because CI does not run there).

## Test plan
- [ ] Confirm `test/ExportingAssembly/MiscExports.cs` exports `OnlyOnFreeBSD`
- [ ] Confirm `test/DNNE.UnitTests` still references `OnlyOnFreeBSD`
- [ ] Run existing unit tests on a supported CI OS (Linux/Windows/macOS) to ensure no regressions
- [ ] If FreeBSD is available, verify `OnlyOnFreeBSD` resolves and the platform guard test passes