### PR TITLE
Fix self-referential Append that garbles multi-platform #endif comments.

### DIFF
--- a/src/dnne-gen/C99Emitter.cs
+++ b/src/dnne-gen/C99Emitter.cs
@@ -299,7 +299,7 @@ $@"#endif // {generatedHeaderDefine}
 
                     var platformMacroSafe = Regex.Replace(os.ToString(), SafeMacroRegEx, "_").ToUpperInvariant();
                     pre.Append($"{delim}defined({platformMacroSafe})");
-                    post.Append($"{post}{delim}{platformMacroSafe}");
+                    post.Append($"{delim}{platformMacroSafe}");
                 }
 
                 if (pre.Length != 0)


### PR DESCRIPTION
The post StringBuilder was interpolating its own contents on each iteration, so guards with multiple platforms produced corrupted #endif comments.